### PR TITLE
Fix remote paste for Codex/macOS, custom SSH port, screenshot files (v2.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clipaste"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "block2",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipaste"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 description = "Fix macOS/Windows screenshot paste in terminal AI tools"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -43,21 +43,40 @@ clipaste can bridge your local clipboard to remote servers over SSH. One-time se
 
 ```bash
 clipaste ssh-setup user@your-server
+clipaste ssh-setup user@your-server -p 22222   # custom SSH port
 ```
 
 This automatically:
-- Installs an xclip shim on the remote server (`~/.local/bin/xclip`)
-- Adds `RemoteForward 18340` to your `~/.ssh/config`
+- Detects the remote OS (`uname -s`) and installs the right helpers
+- On a Linux remote: installs an xclip/wl-paste shim (`~/.local/bin/`)
+- Installs a universal `clipaste-paste` command on every remote
+- Adds `RemoteForward 18340` (and `Port` if you passed `-p`) to your `~/.ssh/config`
 - No extra tools needed on the remote server (just `curl`)
 
-After setup, open a **new** SSH session and use **Ctrl+V** in Claude Code / Codex:
+After setup, open a **new** SSH session:
 
 ```bash
 ssh user@your-server
-claude   # Ctrl+V pastes screenshots from your local Mac
+claude   # Ctrl+V pastes screenshots from your local Mac (Linux remote)
+codex    # run `clipaste-paste`, then paste the printed path (see below)
 ```
 
-### How SSH paste works
+### Pasting in Codex CLI / on a macOS remote
+
+Codex CLI reads the clipboard **in-process** (via X11/NSPasteboard) and bypasses
+the xclip shim, so it can't paste images natively over SSH. macOS remotes have
+the same gap (the tool reads the remote Mac's own, empty clipboard). For both,
+use the `clipaste-paste` helper that `ssh-setup` installs:
+
+```bash
+clipaste-paste            # → /tmp/clipaste-<ts>.png  (a real file on the remote)
+```
+
+Take a screenshot (or copy an image file) on your Mac, run `clipaste-paste` on the
+remote, and hand the printed path to Codex / Claude Code — both accept an image
+file path. This works the same on Linux and macOS remotes.
+
+### How SSH paste works (Claude Code, Linux remote)
 
 ```
 Local Mac                          Remote Server (via SSH)
@@ -107,12 +126,19 @@ HTTP server ◄──── WSL2 network ────────► curl $WIN_H
 |----------|----------|-------------|
 | **Local terminal (macOS)** | **Cmd+V** | Ghostty/iTerm2 paste file path → tool reads file |
 | **Local terminal** | **Ctrl+V** | Claude Code reads clipboard image directly |
-| **SSH remote** | **Ctrl+V** | xclip shim → HTTP tunnel → local PNG |
-| **WSL2** | **Ctrl+V** | xclip shim → HTTP → Windows host PNG |
+| **SSH remote — Claude Code (Linux)** | **Ctrl+V** | xclip shim → HTTP tunnel → local PNG |
+| **SSH remote — Codex / macOS remote** | `clipaste-paste` | helper fetches PNG → paste the printed path |
+| **WSL2 — Claude Code** | **Ctrl+V** | xclip shim → HTTP → Windows host PNG |
+| **WSL2 — Codex** | `clipaste-paste` | helper fetches PNG → paste the printed path |
 
-**Tip:** Ctrl+V works everywhere (local, SSH, WSL2). Cmd+V is a macOS local-only bonus.
+**Tip:** On a Linux remote, Claude Code pastes with Ctrl+V. Codex CLI and macOS
+remotes use the `clipaste-paste` helper instead (Codex bypasses the xclip shim).
 
-> **Important:** In an SSH session, **always use Ctrl+V**, never Cmd+V. Cmd+V pastes the local Mac path as text, which the remote agent cannot read. Ctrl+V triggers the xclip shim, which fetches the image through the SSH tunnel and gives the remote agent a real remote path.
+> **Important:** In an SSH session with Claude Code, **use Ctrl+V**, never Cmd+V —
+> Cmd+V pastes the local Mac path as text, which the remote agent cannot read.
+> Ctrl+V triggers the xclip shim, which fetches the image through the SSH tunnel.
+> For **Codex CLI** (which doesn't use the shim) or a **macOS remote**, run
+> `clipaste-paste` and hand the printed path to the agent.
 
 ## Compatibility
 
@@ -128,9 +154,13 @@ HTTP server ◄──── WSL2 network ────────► curl $WIN_H
 
 | AI Tool | Local | SSH Remote | WSL2 |
 |---------|:-----:|:----------:|:----:|
-| Claude Code | ✅ | ✅ | ✅ |
-| Codex CLI   | ✅ | ✅ | ✅ |
-| Cursor CLI  | ✅ | ✅ | ✅ |
+| Claude Code | ✅ | ✅ Ctrl+V | ✅ Ctrl+V |
+| Codex CLI   | ✅ | ⚠️ via `clipaste-paste` | ⚠️ via `clipaste-paste` |
+| Cursor CLI  | ✅ | ✅ Ctrl+V | ✅ Ctrl+V |
+
+> Codex reads the clipboard in-process and bypasses the xclip shim, so it can't
+> paste images natively over SSH/WSL2 — use the `clipaste-paste` helper. macOS
+> remotes (any tool) also use `clipaste-paste`. See [SSH Remote Paste](#ssh-remote-paste).
 
 ## Managing
 
@@ -161,11 +191,24 @@ macOS screenshots place raw TIFF/PNG image data on the clipboard, but terminals 
 
 ### How do I paste clipboard images over SSH?
 
-Run `clipaste ssh-setup user@your-server` once on your local machine. This installs a lightweight xclip shim on the remote server and configures an SSH tunnel. After setup, open a new SSH session and press **Ctrl+V** in Claude Code or Codex — the image is fetched from your local machine through the tunnel automatically.
+Run `clipaste ssh-setup user@your-server` once on your local machine (add `-p PORT`
+for a non-default SSH port). It detects the remote OS, installs a lightweight
+xclip shim (Linux) plus a universal `clipaste-paste` helper, and configures an SSH
+tunnel. After setup, open a new SSH session:
+
+- **Claude Code on a Linux remote:** press **Ctrl+V** — the image is fetched
+  through the tunnel automatically.
+- **Codex CLI, or any tool on a macOS remote:** run `clipaste-paste` and hand the
+  printed path to the agent. Codex reads the clipboard in-process and bypasses the
+  xclip shim, so it cannot paste natively over SSH; the helper is the working path.
 
 ### Does clipaste work with WSL2?
 
-Yes. Run `clipaste wsl-setup` inside your WSL2 environment. This installs an xclip shim that connects directly to clipaste.exe on the Windows host — no SSH tunnel needed. After setup, **Ctrl+V** in Claude Code or Codex inside WSL2 fetches screenshots from the Windows clipboard.
+Yes. Run `clipaste wsl-setup` inside your WSL2 environment. This installs an xclip
+shim (used by Claude Code) plus the `clipaste-paste` helper (used by Codex),
+connecting directly to clipaste.exe on the Windows host — no SSH tunnel needed.
+After setup, **Ctrl+V** in Claude Code fetches screenshots from the Windows
+clipboard; for Codex, run `clipaste-paste` and paste the printed path.
 
 ### How much memory and CPU does clipaste use?
 
@@ -173,7 +216,7 @@ clipaste uses approximately 9 MB of RAM and 0% CPU when idle. It is written in R
 
 ### Which terminals and AI tools does clipaste support?
 
-clipaste works with Ghostty, Alacritty, iTerm2, Terminal.app, WezTerm, Kitty, and Windows Terminal. It supports Claude Code, Codex CLI, and Cursor CLI. Both **Cmd+V** (macOS local) and **Ctrl+V** (all platforms including SSH and WSL2) are supported. See the compatibility tables above for the full matrix.
+clipaste works with Ghostty, Alacritty, iTerm2, Terminal.app, WezTerm, Kitty, and Windows Terminal. It supports Claude Code, Codex CLI, and Cursor CLI. **Cmd+V** (macOS local) and **Ctrl+V** (local, plus SSH/WSL2 for shim-based tools like Claude Code) are supported; Codex CLI and macOS remotes use the `clipaste-paste` helper. See the compatibility tables above for the full matrix.
 
 ## How is this different from...
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
-pub const VERSION: &str = "2.3.0";
+pub const VERSION: &str = "2.4.0";
 pub const DEFAULT_PORT: u16 = 18340;
 
 /// Shared state: path to the most recently saved screenshot PNG
@@ -132,6 +132,39 @@ pub fn tiff_to_png(tiff_data: &[u8]) -> Option<Vec<u8>> {
     Some(buf)
 }
 
+/// Read an image file from disk and return PNG bytes.
+///
+/// Used when the clipboard holds a *file URL* pointing to an image (e.g. a macOS
+/// screenshot saved to disk, then copied in Finder) — see issue #5. Only formats
+/// the bundled `image` decoder supports are handled (png passthrough, tiff, bmp);
+/// macOS screenshots are PNG by default, which is the common case. Returns None
+/// for unsupported formats so the caller can skip cleanly rather than serve
+/// mislabeled bytes.
+#[cfg(target_os = "macos")]
+pub fn image_file_to_png(path: &std::path::Path) -> Option<Vec<u8>> {
+    let ext = path.extension()?.to_str()?.to_lowercase();
+    let bytes = fs::read(path).ok()?;
+    match ext.as_str() {
+        "png" => Some(bytes), // already PNG — pass through unchanged
+        "tif" | "tiff" => tiff_to_png(&bytes),
+        "bmp" => {
+            let img = image::load_from_memory_with_format(&bytes, ImageFormat::Bmp).ok()?;
+            let rgba = img.to_rgba8();
+            let mut buf = Vec::new();
+            PngEncoder::new(Cursor::new(&mut buf))
+                .write_image(
+                    rgba.as_raw(),
+                    rgba.width(),
+                    rgba.height(),
+                    image::ExtendedColorType::Rgba8,
+                )
+                .ok()?;
+            Some(buf)
+        }
+        _ => None,
+    }
+}
+
 /// Convert Windows DIB (CF_DIB) bytes to PNG bytes
 #[cfg(target_os = "windows")]
 pub fn dib_to_png(dib_data: &[u8]) -> Option<Vec<u8>> {
@@ -190,9 +223,14 @@ pub fn print_help() {
 USAGE
   clipaste                       Run daemon (clipboard watcher + HTTP server)
   clipaste ssh-setup user@host   Configure remote server for image paste via SSH
+                                 (add -p PORT for a custom SSH port)
   clipaste wsl-setup             Configure WSL2 for image paste from Windows host
   clipaste --version             Print version
   clipaste --help                Show this help
+
+  On the remote, ssh-setup/wsl-setup also install a `clipaste-paste` command:
+  it fetches the current clipboard image into a real file and prints its path.
+  Use it with Codex CLI (which bypasses the xclip shim) or any macOS remote.
 
 WHAT IT DOES
   Local:  Watches the clipboard. When a screenshot is detected, saves it as
@@ -200,6 +238,8 @@ WHAT IT DOES
 
   SSH:    Runs an HTTP server on port {DEFAULT_PORT}. Use 'ssh-setup' to
           configure SSH RemoteForward + xclip shim on a remote server.
+          Claude Code (Linux remote) pastes natively with Ctrl+V; Codex CLI
+          and macOS remotes use the `clipaste-paste` helper.
 
   WSL2:   Run 'wsl-setup' inside WSL2 to install xclip shim that fetches
           images from clipaste.exe on the Windows host. No SSH needed.

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -87,6 +87,76 @@ fn read_png_data(pb: &NSPasteboard) -> Option<Vec<u8>> {
     None
 }
 
+/// Minimal percent-decoding for file URLs (e.g. `%20` → space).
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// If the clipboard holds a file URL pointing to an image file, return its path.
+///
+/// This covers the "screenshot saved to disk then copied" case (issue #5): the
+/// clipboard carries a `public.file-url`, not image bits. We only accept image
+/// extensions the bundled decoder can serve (png/tiff/bmp).
+fn image_file_url_on_clipboard(pb: &NSPasteboard) -> Option<std::path::PathBuf> {
+    let data = pb.dataForType(&file_url_type())?;
+    let raw = String::from_utf8(data.to_vec()).ok()?;
+    let raw = raw.trim();
+    let path = match raw.strip_prefix("file://") {
+        // file:///Users/... → strip scheme, drop the (empty) host, percent-decode
+        Some(rest) => percent_decode(rest.trim_start_matches(|c| c != '/')),
+        None => raw.to_string(),
+    };
+    let pb_path = std::path::PathBuf::from(path);
+    let ext = pb_path.extension()?.to_str()?.to_lowercase();
+    let is_supported_image = matches!(ext.as_str(), "png" | "tif" | "tiff" | "bmp");
+    if is_supported_image && pb_path.is_file() {
+        Some(pb_path)
+    } else {
+        None
+    }
+}
+
+/// Make a clipboard image *file* available to the HTTP server (for remote
+/// `clipaste-paste`) without touching the local clipboard — local Cmd+V keeps
+/// pasting whatever it pasted before. Issue #5.
+fn capture_image_file(src: &std::path::Path, latest: &common::LatestImage) {
+    let png = match common::image_file_to_png(src) {
+        Some(p) => p,
+        None => {
+            common::log("skip: clipboard file is not a supported image format");
+            return;
+        }
+    };
+    let tmp = match common::save_png_to_temp(&png) {
+        Some(p) => p,
+        None => return,
+    };
+    if let Ok(mut guard) = latest.lock() {
+        *guard = Some(tmp);
+    }
+    common::log(&format!(
+        "captured clipboard image file ({} bytes) for remote paste",
+        png.len()
+    ));
+    common::clean_old_temp_files();
+}
+
 fn normalize(pb: &NSPasteboard, latest: &common::LatestImage) {
     let png_data = match read_png_data(pb) {
         Some(d) => d,
@@ -205,7 +275,14 @@ pub fn run(latest: common::LatestImage) {
         }
 
         if !is_image_only_clipboard(&pb) {
-            common::log("skip: clipboard has file-url or text");
+            // Not raw image bits. But the clipboard may hold a *file URL* to an
+            // image (screenshot saved to disk then copied) — issue #5. Serve that
+            // file to the HTTP server for remote `clipaste-paste`, without
+            // rewriting the local clipboard.
+            match image_file_url_on_clipboard(&pb) {
+                Some(src) => capture_image_file(&src, &latest),
+                None => common::log("skip: clipboard has file-url or text"),
+            }
             return;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,16 @@ fn main() {
         return;
     }
 
-    // clipaste ssh-setup user@host
+    // clipaste ssh-setup [-p PORT] user@host [-p PORT]
     if args.len() >= 3 && args[1] == "ssh-setup" {
-        ssh_setup::run_ssh(&args[2]);
+        match parse_ssh_setup_args(&args[2..]) {
+            Ok((host, ssh_port)) => ssh_setup::run_ssh(&host, ssh_port),
+            Err(e) => {
+                eprintln!("clipaste ssh-setup: {e}");
+                eprintln!("usage: clipaste ssh-setup [-p PORT] user@host");
+                std::process::exit(1);
+            }
+        }
         return;
     }
 
@@ -45,5 +52,109 @@ fn main() {
     {
         eprintln!("clipaste: unsupported platform");
         std::process::exit(1);
+    }
+}
+
+/// Parse `ssh-setup` arguments into (host, optional SSH port).
+///
+/// Accepts a `-p PORT` / `--port PORT` flag in any position, e.g.:
+///   ssh-setup user@host -p 22222
+///   ssh-setup -p 22222 user@host
+/// The first non-flag argument is the host. This `-p` is the *SSH connection*
+/// port; the clipaste HTTP port stays fixed at `common::DEFAULT_PORT`.
+fn parse_ssh_setup_args(args: &[String]) -> Result<(String, Option<u16>), String> {
+    let mut host: Option<String> = None;
+    let mut ssh_port: Option<u16> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        if a == "-p" || a == "--port" {
+            let val = args
+                .get(i + 1)
+                .ok_or_else(|| format!("{a} requires a port number"))?;
+            ssh_port = Some(
+                val.parse::<u16>()
+                    .map_err(|_| format!("invalid port: {val}"))?,
+            );
+            i += 2;
+            continue;
+        }
+        if let Some(rest) = a.strip_prefix("--port=") {
+            ssh_port = Some(rest.parse::<u16>().map_err(|_| format!("invalid port: {rest}"))?);
+            i += 1;
+            continue;
+        }
+        if let Some(rest) = a.strip_prefix("-p") {
+            // -p22222 (attached form)
+            if !rest.is_empty() {
+                ssh_port = Some(rest.parse::<u16>().map_err(|_| format!("invalid port: {rest}"))?);
+                i += 1;
+                continue;
+            }
+        }
+        if a.starts_with('-') {
+            return Err(format!("unknown flag: {a}"));
+        }
+        if host.is_none() {
+            host = Some(a.clone());
+        } else {
+            return Err(format!("unexpected argument: {a}"));
+        }
+        i += 1;
+    }
+
+    match host {
+        Some(h) => Ok((h, ssh_port)),
+        None => Err("missing host (user@host)".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ssh_setup_args;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn host_only() {
+        let (h, p) = parse_ssh_setup_args(&s(&["user@host"])).unwrap();
+        assert_eq!(h, "user@host");
+        assert_eq!(p, None);
+    }
+
+    #[test]
+    fn host_then_port() {
+        let (h, p) = parse_ssh_setup_args(&s(&["user@host", "-p", "22222"])).unwrap();
+        assert_eq!(h, "user@host");
+        assert_eq!(p, Some(22222));
+    }
+
+    #[test]
+    fn port_then_host() {
+        let (h, p) = parse_ssh_setup_args(&s(&["-p", "2200", "user@host"])).unwrap();
+        assert_eq!(h, "user@host");
+        assert_eq!(p, Some(2200));
+    }
+
+    #[test]
+    fn long_and_attached_forms() {
+        let (_, p1) = parse_ssh_setup_args(&s(&["h", "--port", "10"])).unwrap();
+        assert_eq!(p1, Some(10));
+        let (_, p2) = parse_ssh_setup_args(&s(&["h", "--port=11"])).unwrap();
+        assert_eq!(p2, Some(11));
+        let (_, p3) = parse_ssh_setup_args(&s(&["h", "-p12"])).unwrap();
+        assert_eq!(p3, Some(12));
+    }
+
+    #[test]
+    fn errors() {
+        assert!(parse_ssh_setup_args(&s(&["-p"])).is_err()); // missing value
+        assert!(parse_ssh_setup_args(&s(&["-p", "abc", "h"])).is_err()); // bad port
+        assert!(parse_ssh_setup_args(&s(&["-p", "70000", "h"])).is_err()); // overflow u16
+        assert!(parse_ssh_setup_args(&s(&["-x", "h"])).is_err()); // unknown flag
+        assert!(parse_ssh_setup_args(&s(&[])).is_err()); // no host
     }
 }

--- a/src/ssh_setup.rs
+++ b/src/ssh_setup.rs
@@ -75,13 +75,80 @@ else
 fi
 "#;
 
-fn install_shims_via_ssh(host: &str, clipaste_url: &str) -> Result<(), String> {
+/// clipaste-paste helper — fetches the current clipboard image into a real file
+/// on the remote host and prints its path. Unlike the xclip/wl-paste shims (which
+/// only work for tools that shell out to those commands, e.g. Claude Code), this
+/// works for ANY tool that accepts an image file path — including Codex CLI, which
+/// reads the clipboard in-process via X11/NSPasteboard and bypasses the shims.
+/// Also the only working path on a macOS remote (where xclip/wl-paste don't apply).
+const CLIPASTE_PASTE_TEMPLATE: &str = r#"#!/bin/bash
+# clipaste-paste — fetch the current clipboard image from your LOCAL machine
+# (through the clipaste SSH tunnel / WSL bridge) into a real file on THIS host,
+# then print the path. Use it when your tool can't read the clipboard directly:
+#   - Codex CLI (reads clipboard in-process, bypasses the xclip shim)
+#   - any macOS remote (xclip/wl-paste don't apply there)
+#
+# Usage: run `clipaste-paste`, then hand the printed path to your tool.
+# Installed by: clipaste ssh-setup / clipaste wsl-setup
+
+CLIPASTE_URL="__CLIPASTE_URL__"
+
+if ! curl -sf "${CLIPASTE_URL}/clipboard/type" 2>/dev/null | grep -q '"image"'; then
+    echo "clipaste-paste: no image on clipboard — take a screenshot (or copy an image file) on your local machine first" >&2
+    exit 1
+fi
+
+out="${TMPDIR:-/tmp}/clipaste-$(date +%s)-$$.png"
+if curl -sf -o "$out" "${CLIPASTE_URL}/clipboard/image" 2>/dev/null && [ -s "$out" ]; then
+    echo "$out"
+    exit 0
+fi
+
+rm -f "$out"
+echo "clipaste-paste: failed to fetch image from ${CLIPASTE_URL} (is the clipaste daemon running locally and the tunnel up?)" >&2
+exit 1
+"#;
+
+/// Append `-p PORT` to an ssh argument list when a custom SSH port is given.
+fn ssh_port_args(ssh_port: Option<u16>) -> Vec<String> {
+    match ssh_port {
+        Some(p) => vec!["-p".to_string(), p.to_string()],
+        None => vec![],
+    }
+}
+
+/// Install shims on the remote and report the detected remote OS ("Darwin" /
+/// "Linux" / "Unknown").
+///
+/// A single remote `bash -s` invocation detects the OS via `uname -s` and then
+/// always installs `clipaste-paste` (works for every tool, every OS), but
+/// installs the xclip/wl-paste shims only on Linux (they are useless on macOS,
+/// where tools read the pasteboard directly rather than via xclip). Doing the OS
+/// branch on the remote avoids a second ssh round-trip / password prompt and
+/// keeps the remote authoritative about its own platform.
+fn install_shims_via_ssh(
+    host: &str,
+    clipaste_url: &str,
+    ssh_port: Option<u16>,
+) -> Result<String, String> {
     let xclip_shim = XCLIP_SHIM_TEMPLATE.replace("__CLIPASTE_URL__", clipaste_url);
     let wl_paste_shim = WL_PASTE_SHIM_TEMPLATE.replace("__CLIPASTE_URL__", clipaste_url);
+    let clipaste_paste = CLIPASTE_PASTE_TEMPLATE.replace("__CLIPASTE_URL__", clipaste_url);
 
     let setup_script = format!(
         r#"
+set -e
+OS="$(uname -s)"
 mkdir -p ~/.local/bin
+
+# clipaste-paste: universal helper, installed on every platform
+cat > ~/.local/bin/clipaste-paste << 'SHIMEOF'
+{clipaste_paste}
+SHIMEOF
+chmod +x ~/.local/bin/clipaste-paste
+
+# xclip/wl-paste shims: only meaningful on Linux
+if [ "$OS" = "Linux" ]; then
 cat > ~/.local/bin/xclip << 'SHIMEOF'
 {xclip_shim}
 SHIMEOF
@@ -91,6 +158,7 @@ cat > ~/.local/bin/wl-paste << 'SHIMEOF'
 {wl_paste_shim}
 SHIMEOF
 chmod +x ~/.local/bin/wl-paste
+fi
 
 # Ensure ~/.local/bin is in PATH
 if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
@@ -101,12 +169,17 @@ if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
         fi
     done
 fi
+echo "CLIPASTE_OS=$OS"
 echo "OK"
 "#
     );
 
+    let mut args = ssh_port_args(ssh_port);
+    args.push(host.to_string());
+    args.push("bash -s".to_string());
+
     let result = Command::new("ssh")
-        .args([host, "bash -s"])
+        .args(&args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -117,34 +190,42 @@ echo "OK"
         });
 
     match result {
-        Ok(o) if o.status.success() => Ok(()),
+        Ok(o) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            let os = stdout
+                .lines()
+                .find_map(|l| l.trim().strip_prefix("CLIPASTE_OS="))
+                .unwrap_or("Unknown")
+                .to_string();
+            Ok(os)
+        }
         Ok(o) => Err(String::from_utf8_lossy(&o.stderr).trim().to_string()),
         Err(e) => Err(format!("SSH error: {e}")),
     }
 }
 
+/// Write a shim script to `path` and mark it executable (best-effort, Unix).
+fn write_executable(path: &std::path::Path, content: &str, label: &str) -> Result<(), String> {
+    std::fs::write(path, content).map_err(|e| format!("write {label}: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).ok();
+    }
+    Ok(())
+}
+
 fn install_shims_locally(clipaste_url: &str) -> Result<(), String> {
     let xclip_shim = XCLIP_SHIM_TEMPLATE.replace("__CLIPASTE_URL__", clipaste_url);
     let wl_paste_shim = WL_PASTE_SHIM_TEMPLATE.replace("__CLIPASTE_URL__", clipaste_url);
+    let clipaste_paste = CLIPASTE_PASTE_TEMPLATE.replace("__CLIPASTE_URL__", clipaste_url);
 
     let bin_dir = dirs_home().join(".local/bin");
     std::fs::create_dir_all(&bin_dir).map_err(|e| format!("mkdir: {e}"))?;
 
-    let xclip_path = bin_dir.join("xclip");
-    std::fs::write(&xclip_path, xclip_shim).map_err(|e| format!("write xclip: {e}"))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&xclip_path, std::fs::Permissions::from_mode(0o755)).ok();
-    }
-
-    let wl_paste_path = bin_dir.join("wl-paste");
-    std::fs::write(&wl_paste_path, wl_paste_shim).map_err(|e| format!("write wl-paste: {e}"))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&wl_paste_path, std::fs::Permissions::from_mode(0o755)).ok();
-    }
+    write_executable(&bin_dir.join("xclip"), &xclip_shim, "xclip")?;
+    write_executable(&bin_dir.join("wl-paste"), &wl_paste_shim, "wl-paste")?;
+    write_executable(&bin_dir.join("clipaste-paste"), &clipaste_paste, "clipaste-paste")?;
 
     // Ensure PATH
     let bashrc = dirs_home().join(".bashrc");
@@ -162,8 +243,11 @@ fn install_shims_locally(clipaste_url: &str) -> Result<(), String> {
 
 // ─── SSH Setup ───
 
-pub fn run_ssh(host: &str) {
+pub fn run_ssh(host: &str, ssh_port: Option<u16>) {
     println!("clipaste ssh-setup for {host}");
+    if let Some(p) = ssh_port {
+        println!("(SSH port {p})");
+    }
     println!();
 
     // Step 1: Check local HTTP server
@@ -177,23 +261,26 @@ pub fn run_ssh(host: &str) {
     }
     println!("OK");
 
-    // Step 2: Deploy shims to remote
+    // Step 2: Deploy shims to remote (also detects the remote OS)
     let url = format!("http://127.0.0.1:{}", common::DEFAULT_PORT);
-    print!("[2/3] Installing shims on {host}... ");
+    print!("[2/3] Installing helper on {host}... ");
     std::io::stdout().flush().unwrap();
-    match install_shims_via_ssh(host, &url) {
-        Ok(()) => println!("OK"),
+    let remote_os = match install_shims_via_ssh(host, &url, ssh_port) {
+        Ok(os) => {
+            println!("OK ({os})");
+            os
+        }
         Err(e) => {
             println!("FAILED");
             eprintln!("  {e}");
             std::process::exit(1);
         }
-    }
+    };
 
-    // Step 3: Configure SSH RemoteForward
+    // Step 3: Configure SSH RemoteForward (+ custom Port)
     print!("[3/3] Configuring SSH RemoteForward... ");
     std::io::stdout().flush().unwrap();
-    match add_remote_forward(host) {
+    match add_remote_forward(host, ssh_port) {
         Ok(msg) => println!("{msg}"),
         Err(e) => {
             println!("FAILED");
@@ -203,10 +290,24 @@ pub fn run_ssh(host: &str) {
     }
 
     println!();
-    println!("Setup complete! Next steps:");
+    println!("Setup complete!");
     println!("  1. Open a NEW SSH session: ssh {host}");
-    println!("  2. Take a screenshot on your Mac");
-    println!("  3. In remote Claude Code / Codex, press Ctrl+V");
+    println!("  2. Take a screenshot (or copy an image file) on your Mac");
+    if remote_os == "Darwin" {
+        // macOS remote: xclip/wl-paste don't apply; tools read the *remote*
+        // (empty) pasteboard. The clipaste-paste helper is the working path.
+        println!("  3. In the remote shell, run: clipaste-paste");
+        println!("     then hand the printed path to Claude Code / Codex");
+        println!();
+        println!("Note: this is a macOS remote — native Ctrl+V reads the remote Mac's");
+        println!("clipboard (empty), so use the `clipaste-paste` helper instead.");
+    } else {
+        println!("  3a. Claude Code: press Ctrl+V (fetched via the xclip shim)");
+        println!("  3b. Codex CLI:  run `clipaste-paste` and paste the printed path");
+        println!();
+        println!("Note: Codex reads the clipboard in-process and bypasses the xclip");
+        println!("shim, so it can't paste images natively over SSH — use clipaste-paste.");
+    }
 }
 
 // ─── WSL Setup ───
@@ -288,33 +389,53 @@ fn detect_wsl_host_ip() -> Option<String> {
     None
 }
 
-fn add_remote_forward(host: &str) -> Result<String, String> {
+fn add_remote_forward(host: &str, ssh_port: Option<u16>) -> Result<String, String> {
     let ssh_config_path = dirs_home().join(".ssh/config");
     let ssh_dir = ssh_config_path.parent().unwrap();
     if !ssh_dir.exists() {
         std::fs::create_dir_all(ssh_dir)
             .map_err(|e| format!("Cannot create ~/.ssh: {e}"))?;
     }
-    let port = common::DEFAULT_PORT;
     let config_content = std::fs::read_to_string(&ssh_config_path).unwrap_or_default();
-    let forward_line = format!("RemoteForward {port} 127.0.0.1:{port}");
     let host_pattern = extract_hostname(host);
 
-    // Two-pass approach:
-    // Pass 1: find which line to inject after (matching by Host alias or HostName)
-    // Pass 2: build new config with injection
+    match build_ssh_config(&config_content, &host_pattern, ssh_port) {
+        (None, msg) => Ok(msg),
+        (Some(new_config), msg) => {
+            std::fs::write(&ssh_config_path, &new_config)
+                .map_err(|e| format!("Cannot write ~/.ssh/config: {e}"))?;
+            Ok(msg)
+        }
+    }
+}
 
-    let lines: Vec<&str> = config_content.lines().collect();
+/// Pure transformation: given the existing `~/.ssh/config` text, inject a
+/// `RemoteForward` (and a `Port` when a custom SSH port is given) into the block
+/// matching `host_pattern`. Returns `(None, msg)` when nothing needs changing
+/// ("already configured"), or `(Some(new_config), msg)` with the rewritten file.
+///
+/// `RemoteForward` is the idempotency key. A `Port` directive already present in
+/// the matching block is left untouched (we never override the user's port).
+fn build_ssh_config(
+    existing: &str,
+    host_pattern: &str,
+    ssh_port: Option<u16>,
+) -> (Option<String>, String) {
+    let port = common::DEFAULT_PORT;
+    let forward_line = format!("RemoteForward {port} 127.0.0.1:{port}");
+
+    let lines: Vec<&str> = existing.lines().collect();
     let mut inject_after: Option<usize> = None;
     let mut in_matching_block = false;
     let mut found_existing_forward = false;
+    let mut found_existing_port = false;
 
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
 
         // New Host block starts — reset per-block matching state.
-        // Note: found_existing_forward is latching (never reset), so a
-        // forward found in an earlier matching block survives later blocks.
+        // Note: found_existing_* is latching (never reset), so a directive
+        // found in an earlier matching block survives later blocks.
         if trimmed.starts_with("Host ") {
             in_matching_block = false;
 
@@ -344,35 +465,59 @@ fn add_remote_forward(host: &str) -> Result<String, String> {
             }
         }
 
-        // Check if any matching block already has the forward (latching)
+        // Check if any matching block already has the forward / port (latching)
         if in_matching_block && trimmed.contains(&forward_line) {
             found_existing_forward = true;
         }
+        if in_matching_block
+            && (trimmed.starts_with("Port ") || trimmed.starts_with("Port\t"))
+        {
+            found_existing_port = true;
+        }
     }
 
-    if found_existing_forward {
-        return Ok("already configured".to_string());
+    // Lines to inject after the chosen anchor (preserve a stable order).
+    let mut inject_lines: Vec<String> = Vec::new();
+    if !found_existing_forward {
+        inject_lines.push(forward_line.clone());
+    }
+    if let Some(p) = ssh_port {
+        if !found_existing_port {
+            inject_lines.push(format!("Port {p}"));
+        }
     }
 
-    // Pass 2: build new config
+    if inject_lines.is_empty() {
+        return (None, "already configured".to_string());
+    }
+
     let mut new_config = String::new();
     for (i, line) in lines.iter().enumerate() {
         new_config.push_str(line);
         new_config.push('\n');
         if Some(i) == inject_after {
-            new_config.push_str(&format!("    {forward_line}\n"));
+            for l in &inject_lines {
+                new_config.push_str(&format!("    {l}\n"));
+            }
         }
     }
 
     if inject_after.is_none() {
         new_config.push_str(&format!(
-            "\n# clipaste remote paste\nHost clipaste-{host_pattern}\n    HostName {host_pattern}\n    {forward_line}\n"
+            "\n# clipaste remote paste\nHost clipaste-{host_pattern}\n    HostName {host_pattern}\n"
         ));
+        if let Some(p) = ssh_port {
+            new_config.push_str(&format!("    Port {p}\n"));
+        }
+        new_config.push_str(&format!("    {forward_line}\n"));
     }
 
-    std::fs::write(&ssh_config_path, &new_config)
-        .map_err(|e| format!("Cannot write ~/.ssh/config: {e}"))?;
-    Ok("OK (added RemoteForward)".to_string())
+    let msg = if ssh_port.is_some() && !found_existing_port {
+        "OK (added RemoteForward + Port)".to_string()
+    } else {
+        "OK (added RemoteForward)".to_string()
+    };
+    (Some(new_config), msg)
 }
 
 fn dirs_home() -> std::path::PathBuf {
@@ -390,3 +535,97 @@ fn extract_hostname(host: &str) -> String {
         host.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_hostname_strips_user() {
+        assert_eq!(extract_hostname("user@host"), "host");
+        assert_eq!(extract_hostname("host"), "host");
+        assert_eq!(extract_hostname("a@b@host"), "host");
+    }
+
+    #[test]
+    fn ssh_port_args_shape() {
+        assert!(ssh_port_args(None).is_empty());
+        assert_eq!(ssh_port_args(Some(2200)), vec!["-p", "2200"]);
+    }
+
+    #[test]
+    fn new_block_when_no_match() {
+        let (out, msg) = build_ssh_config("", "host", None);
+        let out = out.unwrap();
+        assert!(out.contains("Host clipaste-host"));
+        assert!(out.contains("HostName host"));
+        assert!(out.contains("RemoteForward 18340 127.0.0.1:18340"));
+        assert!(!out.contains("Port "));
+        assert_eq!(msg, "OK (added RemoteForward)");
+    }
+
+    #[test]
+    fn new_block_with_custom_port() {
+        let (out, msg) = build_ssh_config("", "host", Some(22222));
+        let out = out.unwrap();
+        assert!(out.contains("Host clipaste-host"));
+        assert!(out.contains("    Port 22222\n"));
+        assert!(out.contains("RemoteForward 18340 127.0.0.1:18340"));
+        assert_eq!(msg, "OK (added RemoteForward + Port)");
+    }
+
+    #[test]
+    fn injects_into_existing_block_after_hostname() {
+        let existing = "Host myserver\n    HostName 10.0.0.1\n    User me\n";
+        let (out, msg) = build_ssh_config(existing, "myserver", Some(22222));
+        let out = out.unwrap();
+        // Injected right after HostName, before User
+        let hn = out.find("HostName 10.0.0.1").unwrap();
+        let fwd = out.find("RemoteForward").unwrap();
+        let port = out.find("Port 22222").unwrap();
+        let user = out.find("User me").unwrap();
+        assert!(hn < fwd && fwd < user);
+        assert!(hn < port && port < user);
+        assert_eq!(msg, "OK (added RemoteForward + Port)");
+    }
+
+    #[test]
+    fn idempotent_when_forward_present_no_port_requested() {
+        let existing =
+            "Host h\n    HostName h\n    RemoteForward 18340 127.0.0.1:18340\n";
+        let (out, msg) = build_ssh_config(existing, "h", None);
+        assert!(out.is_none());
+        assert_eq!(msg, "already configured");
+    }
+
+    #[test]
+    fn does_not_duplicate_existing_user_port() {
+        // Block already has a Port (the user's real SSH port) and the forward.
+        let existing =
+            "Host h\n    HostName h\n    Port 2222\n    RemoteForward 18340 127.0.0.1:18340\n";
+        let (out, msg) = build_ssh_config(existing, "h", Some(2222));
+        assert!(out.is_none(), "nothing to add → already configured");
+        assert_eq!(msg, "already configured");
+    }
+
+    #[test]
+    fn adds_only_port_when_forward_already_present() {
+        let existing =
+            "Host h\n    HostName h\n    RemoteForward 18340 127.0.0.1:18340\n";
+        let (out, msg) = build_ssh_config(existing, "h", Some(2222));
+        let out = out.unwrap();
+        assert!(out.contains("Port 2222"));
+        assert_eq!(out.matches("RemoteForward 18340").count(), 1);
+        assert_eq!(msg, "OK (added RemoteForward + Port)");
+    }
+
+    #[test]
+    fn skips_wildcard_block() {
+        let existing = "Host *\n    ForwardAgent yes\n";
+        let (out, _) = build_ssh_config(existing, "host", None);
+        let out = out.unwrap();
+        // A dedicated clipaste block is created instead of injecting into Host *
+        assert!(out.contains("Host clipaste-host"));
+    }
+}
+


### PR DESCRIPTION
Root-cause fixes for the open issues. See commit for details.

## Issues addressed
- **#1** Windows/Rust rewrite — already fully implemented in `src/windows.rs`; will close separately.
- **#2** macbook→mac mini — `ssh-setup` detects remote OS (`uname -s`); macOS remotes no longer get useless Linux shims, get the universal `clipaste-paste` helper instead.
- **#3** Custom SSH port — `ssh-setup -p PORT` parses the flag, threads it through ssh + injects `Port` into `~/.ssh/config` (idempotent).
- **#4** Codex over SSH (X11 error) — Codex bypasses the xclip shim (in-process arboard/X11, no env hook in latest codex). New `clipaste-paste` helper fetches the image into a real remote file and prints the path, which Codex/Claude Code can attach.
- **#5** Screenshot-to-file path — macOS daemon now captures clipboard *file-URL* images (without rewriting the local clipboard) so the helper can return them.

## Honesty fix
README previously claimed "Codex SSH ✅✅✅" and that Ctrl+V "triggers the xclip shim" — false for Codex. Corrected to document `clipaste-paste`.

## Verification
- `cargo build --release` ✅, `cargo test` 14 passed ✅, clippy clean (no new warnings) ✅
- Windows target `cargo check` ✅
- `clipaste-paste` returns a valid PNG path ✅
- #5 capture verified end-to-end; local clipboard left untouched ✅