### PR TITLE
Stage images copied from a browser, not just screenshots

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -29,12 +29,37 @@ fn file_url_type() -> Retained<NSPasteboardType> {
     pasteboard_type("public.file-url")
 }
 
-fn filenames_type() -> Retained<NSPasteboardType> {
-    pasteboard_type("NSFilenamesPboardType")
-}
-
 fn string_type() -> Retained<NSPasteboardType> {
     pasteboard_type("public.utf8-plain-text")
+}
+
+/// Decide, from the pasteboard's type list alone, whether the clipboard holds
+/// raw image bits we should stage.
+///
+/// The list length says nothing about the content. A screenshot advertises two
+/// or three types; an image copied out of a Chromium browser advertises eight —
+/// the same bits under several flavors, plus the source markup and Chromium's
+/// private metadata. What decides it is the presence of image bits together
+/// with the absence of a file reference or plain text, because those two mean
+/// the user copied a *file* or *text* and staging the image would hijack an
+/// ordinary paste.
+fn is_image_only(types: &[String]) -> bool {
+    let mut has_image = false;
+    let mut has_file_url = false;
+    let mut has_filenames = false;
+    let mut has_string = false;
+
+    for t in types {
+        match t.as_str() {
+            "public.png" | "public.tiff" => has_image = true,
+            "public.file-url" => has_file_url = true,
+            "NSFilenamesPboardType" => has_filenames = true,
+            "public.utf8-plain-text" => has_string = true,
+            _ => {}
+        }
+    }
+
+    has_image && !has_file_url && !has_filenames && !has_string
 }
 
 /// Check if clipboard has image data but no file URL or string
@@ -44,36 +69,11 @@ fn is_image_only_clipboard(pb: &NSPasteboard) -> bool {
         None => return false,
     };
 
-    let count = types.count();
-    if count > 6 {
-        return false;
-    }
+    let list: Vec<String> = (0..types.count())
+        .map(|i| types.objectAtIndex(i).to_string())
+        .collect();
 
-    let mut has_image = false;
-    let mut has_file_url = false;
-    let mut has_filenames = false;
-    let mut has_string = false;
-
-    let png = png_type();
-    let tiff = tiff_type();
-    let furl = file_url_type();
-    let fnames = filenames_type();
-    let str_type = string_type();
-
-    for i in 0..count {
-        let t: Retained<NSPasteboardType> = types.objectAtIndex(i);
-        if *t == *png || *t == *tiff {
-            has_image = true;
-        } else if *t == *furl {
-            has_file_url = true;
-        } else if *t == *fnames {
-            has_filenames = true;
-        } else if *t == *str_type {
-            has_string = true;
-        }
-    }
-
-    has_image && !has_file_url && !has_filenames && !has_string
+    is_image_only(&list)
 }
 
 /// Read PNG data from clipboard, converting from TIFF if needed
@@ -300,5 +300,65 @@ pub fn run(latest: common::LatestImage) {
     unsafe {
         run_loop.addTimer_forMode(&timer, NSDefaultRunLoopMode);
         run_loop.run();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_image_only;
+
+    fn types(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn screenshot_is_staged() {
+        assert!(is_image_only(&types(&["public.png", "public.tiff"])));
+    }
+
+    /// An image copied out of a Chromium browser (Brave, Chrome, Edge): the
+    /// same bits under several flavors, plus the source markup and Chromium's
+    /// private metadata. Eight types, no file URL, no plain text — still just
+    /// an image. A cap on the number of types rejected this, so the daemon kept
+    /// serving whatever was staged before and remote paste produced a stale
+    /// screenshot.
+    #[test]
+    fn browser_image_is_staged() {
+        assert!(is_image_only(&types(&[
+            "public.png",
+            "Apple PNG pasteboard type",
+            "public.html",
+            "Apple HTML pasteboard type",
+            "org.chromium.internal.source-rfh-token",
+            "org.chromium.source-url",
+            "public.tiff",
+            "NeXT TIFF v4.0 pasteboard type",
+        ])));
+    }
+
+    /// A copied file is a file, however many flavors accompany it.
+    #[test]
+    fn copied_file_is_not_staged() {
+        assert!(!is_image_only(&types(&["public.file-url", "public.png"])));
+        assert!(!is_image_only(&types(&[
+            "NSFilenamesPboardType",
+            "public.png"
+        ])));
+    }
+
+    /// A web-page selection carries markup and an image alongside the text.
+    /// Staging it would hijack an ordinary text paste.
+    #[test]
+    fn text_selection_is_not_staged() {
+        assert!(!is_image_only(&types(&[
+            "public.utf8-plain-text",
+            "public.html",
+            "public.png"
+        ])));
+    }
+
+    #[test]
+    fn empty_clipboard_is_not_staged() {
+        assert!(!is_image_only(&[]));
     }
 }


### PR DESCRIPTION
## What happens

Copy an image out of a Chromium browser (Brave/Chrome/Edge — e.g. an image in a web chat), then paste in Claude Code, locally or over SSH. You get an image — but it is the *previously* staged screenshot, not the one you just copied.

It fails silently and reproduces 100% of the time. Because a stale image still arrives, it reads as a caching problem rather than a rejected clipboard, which makes it awkward to diagnose. `clipaste doctor` reports `ok` throughout: an image *is* staged and ready to serve, just not the right one.

## Why

`is_image_only_clipboard` bailed on any clipboard advertising more than six pasteboard types:

```rust
let count = types.count();
if count > 6 {
    return false;
}
```

A screenshot advertises two or three types, so the cap never fires locally. A Chromium image copy advertises eight — the same bits under `public.png` and `public.tiff`, their legacy Apple aliases, the source markup, and Chromium's own metadata:

```
public.png                                [2099704 bytes]
Apple PNG pasteboard type                 [2099704 bytes]
public.html                                    [97 bytes]
Apple HTML pasteboard type                     [97 bytes]
org.chromium.internal.source-rfh-token         [24 bytes]
org.chromium.source-url                        [21 bytes]
public.tiff                               [8809068 bytes]
NeXT TIFF v4.0 pasteboard type            [8809068 bytes]
```

Eight > 6, so the clipboard was reported as not-image, the daemon logged `skip: clipboard has file-url or text`, and `latest` kept pointing at the previous capture.

I confirmed this against the running daemon rather than inferring it, by building `main` with a temporary diagnostic log:

```
DIAG: count=4 image=true furl=false fnames=false str=false   → normalized   (screenshot)
DIAG: bail because count=8 > 6                               → skip         (browser copy)
```

## The fix

The type count never carried information about the content — a rich clipboard is not a text clipboard. What decides it is image bits present, and no file reference or plain text; those two mean the user copied a *file* or *text*, where staging the image would hijack an ordinary paste. Those flags were already computed, so the cap is simply dropped.

Per AGENTS.md ("pure functions for anything with logic", "reproduce the failure shape in a test before fixing it"), the decision moves into a pure `is_image_only(&[String])` and `is_image_only_clipboard` just collects the type list and calls it.

## Tests

Five cases against the real type lists: screenshot, Chromium image copy, copied file (`public.file-url` and `NSFilenamesPboardType`), web-page selection carrying text + markup + image, and an empty clipboard.

`browser_image_is_staged` fails on `main` and passes with this change — I verified that direction explicitly by restoring the cap and watching only that test go red.

- `cargo test` — 46 passed, 0 failed
- `cargo clippy --all-targets` — no new warnings (the two `thread_local` const suggestions are pre-existing and untouched)
- `rustfmt` — the added code is clean; the two pre-existing diffs in this file are left alone so the change stays reviewable

End to end with the patched binary, against the clipboard that triggered it: a browser image copy is now staged, byte-for-byte identical to the clipboard PNG, and a plain-text copy is still left alone.

## One thing I did not fix here

While tracing this I found a second, independent path to the same stale-image symptom: the watcher records `LAST_CHANGE` on the first tick after `changeCount` moves, so if an app clears the pasteboard and writes the image a moment later, the 30 ms timer can read the intermediate state and never revisit that `changeCount`. Reproducible with `clearContents()` → wait → `setData(png)`, which skips permanently. It seemed like a separate concern from the type cap, so I left it out to keep this reviewable — happy to open an issue, or fold in a fix here if you would prefer.