### PR TITLE
Clarify Linux host support and fail before daemon/setup side effects

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,21 @@
+name: Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --locked
+      - run: cargo clippy --locked --all-targets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ clipaste doctor --json
 ```
 
 This is the entry point. It classifies the machine, runs the checks that are
-meaningful for that machine, and returns a `fix` command for anything broken.
+meaningful for that machine, and returns `fix` commands or guidance where available.
 Do not guess at the state of a clipaste install — ask `doctor`.
 
 ```json
@@ -46,20 +46,32 @@ Do not guess at the state of a clipaste install — ask `doctor`.
 
 | Field | Contract |
 |---|---|
-| `role` | `clipboard-host` / `ssh-remote` / `wsl2` — decides which checks apply |
+| `role` | `clipboard-host` / `ssh-remote` / `wsl2` / `unsupported-host` decides which checks apply |
 | `status` | worst of all checks: `ok`, `warn`, `fail` |
 | `checks[].status` | `ok` / `warn` / `fail` |
-| `checks[].fix` | a literal command to run, or `null` |
+| `checks[].fix` | a remediation command or guidance, or `null` when no single command applies |
 | exit code | `0` usable (ok **or** warn), `1` broken, `2` bad arguments |
 
 A `warn` is not a failure. "No screenshot on the clipboard yet" is the normal
 state of a freshly installed machine — do not report it to the user as a
 problem, and do not try to fix it.
 
+`unsupported-host` is an extension of the role contract. Consumers of the JSON
+output must accept it and treat its `fail` status (exit code `1`) as a platform
+capability limit, not as a missing service or dependency. Its `platform` check
+provides guidance in `detail` with `fix: null`.
+
 ### Decide where you are before installing anything
 
 clipaste has two sides and they install differently. Getting this wrong is the
 single most common mistake.
+
+| OS / context | Local clipboard-host daemon | Consumer of another host's clipboard |
+|---|---|---|
+| macOS | Supported | SSH remote via `clipaste-paste` |
+| Windows | Supported | Via WSL2 |
+| Native Linux | Not implemented, on Wayland or X11 | Supported over SSH via shims / `clipaste-paste` |
+| WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
 
 ```
         the machine holding the clipboard          the machine running the agent
@@ -74,6 +86,17 @@ single most common mistake.
 
 `clipaste doctor --json` reports which side you are on as `role`. Trust it over
 `uname`: an SSH session into a Mac is `ssh-remote`, not `clipboard-host`.
+
+The role contract applies in this order:
+
+1. WSL context: `wsl2`, even if SSH environment variables are also present.
+2. An actual SSH session: `ssh-remote`, including SSH into macOS.
+3. A local macOS or Windows machine: `clipboard-host`.
+4. A machine without a local backend but with a configured consumer helper:
+   `ssh-remote`. This includes Linux consumers without SSH environment variables;
+   keep checking their helper and bridge.
+5. An unsupported local machine without those consumer indicators:
+   `unsupported-host`.
 
 ### Install on the clipboard host
 
@@ -92,17 +115,23 @@ irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex
 clipaste doctor --json
 ```
 
-From source (any platform with a Rust toolchain):
+From source:
 
 ```bash
 git clone https://github.com/hqhq1025/clipaste.git
 cd clipaste && cargo build --release
 ```
 
+Linux `cargo build` and `cargo install` remain allowed for development, `doctor`,
+and consumer setup, including `wsl-setup`. Successful compilation does not
+provide a Linux clipboard-host daemon. Do not add a blanket `compile_error!`
+gate: the CLI tools are still needed on Linux consumers.
+
 ### Wire up an SSH remote
 
-Run this **on the clipboard host**, not on the remote. It needs the local daemon
-running, and it edits the local `~/.ssh/config`.
+Run this on the local macOS or Windows clipboard host, not on the Linux
+consumer or other remote. It needs the local daemon running, and it edits the
+local `~/.ssh/config`.
 
 ```bash
 clipaste ssh-setup user@host             # non-interactive; idempotent
@@ -139,7 +168,7 @@ their time:
 
 | Where | Claude Code / Cursor CLI | Codex CLI |
 |---|---|---|
-| Local terminal | `Cmd+V` (macOS) / `Ctrl+V` | `Cmd+V` / `Ctrl+V` |
+| Local terminal (macOS / Windows) | `Cmd+V` (macOS) / `Ctrl+V` | `Cmd+V` (macOS) / `Ctrl+V` |
 | SSH into Linux | `Ctrl+V` | `clipaste-paste`, then paste the printed path |
 | SSH into macOS | `clipaste-paste` | `clipaste-paste` |
 | WSL2 | `Ctrl+V` | `clipaste-paste`, then paste the printed path |
@@ -153,6 +182,13 @@ file path as text, which the remote agent cannot open.
 
 ### Things not to do
 
+- Do not try to fix `unsupported-host` by adding a systemd service, changing
+  PATH, or installing `curl`. Native Linux clipboard hosting is not implemented;
+  the shims only fetch images from a macOS or Windows daemon. For a Linux
+  consumer, run `ssh-setup` on that supported clipboard host and reconnect.
+  For WSL2, require the Windows daemon and run `wsl-setup` inside the distro.
+- Do not classify all Linux machines as `unsupported-host`: actual SSH sessions
+  and configured Linux consumers retain `ssh-remote` diagnostics.
 - Do not bind the daemon to `0.0.0.0` or add firewall exceptions to "fix"
   connectivity. It listens on loopback deliberately; the image bytes on that
   port are the user's screen contents.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ Fix screenshot paste in terminal AI tools — locally, over SSH, and in WSL2.
 
 ## Install
 
+### Supported platforms
+
+The clipboard-host daemon runs on macOS and Windows only. Native Linux clipboard
+hosting is not implemented, for either Wayland or X11.
+
+| OS / context | Local clipboard-host daemon | Consumer of another host's clipboard |
+|---|---|---|
+| macOS | Supported | SSH remote via `clipaste-paste` |
+| Windows | Supported | Via WSL2, as described below |
+| Native Linux | Not implemented | Supported over SSH via shims / `clipaste-paste` |
+| WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
+
+Linux shims fetch images from an existing macOS or Windows daemon; they do not
+watch the Linux desktop clipboard. Run `ssh-setup` on that local Mac or Windows
+clipboard host with its daemon running. On macOS remotes, use `clipaste-paste`.
+
 ### Clipboard history and cache
 
 Starting with v2.4.2, macOS normalization preserves source formats and marks
@@ -43,6 +59,11 @@ irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex
 
 ### Build from source
 
+`cargo build` and `cargo install` remain allowed on Linux for development,
+`doctor`, and consumer setup, including WSL2 setup. A successful build or install
+does not make Linux a supported local clipboard host. There is no blanket
+`compile_error!` gate because these CLI tools are needed on consumer machines.
+
 ```bash
 git clone https://github.com/hqhq1025/clipaste.git
 cd clipaste
@@ -51,7 +72,9 @@ cargo build --release
 
 ## SSH Remote Paste
 
-clipaste can bridge your local clipboard to remote servers over SSH. One-time setup:
+clipaste can bridge your local clipboard to remote servers over SSH. Run this
+one-time setup on your local Mac or Windows clipboard host, with its daemon
+running, not on the Linux consumer:
 
 ```bash
 clipaste ssh-setup user@your-server
@@ -164,7 +187,7 @@ HTTP server ◄──── WSL2 network ────────► curl $WIN_H
 | Scenario | Shortcut | How it works |
 |----------|----------|-------------|
 | **Local terminal (macOS)** | **Cmd+V** | Ghostty/iTerm2 paste file path → tool reads file |
-| **Local terminal** | **Ctrl+V** | Claude Code reads clipboard image directly |
+| **Local terminal (macOS / Windows)** | **Ctrl+V** | Claude Code reads clipboard image directly |
 | **SSH remote — Claude Code (Linux)** | **Ctrl+V** | xclip shim → HTTP tunnel → local PNG |
 | **SSH remote — Codex / macOS remote** | `clipaste-paste` | helper fetches PNG → paste the printed path |
 | **WSL2 — Claude Code** | **Ctrl+V** | xclip shim → HTTP → Windows host PNG |
@@ -180,6 +203,10 @@ remotes use the `clipaste-paste` helper instead (Codex bypasses the xclip shim).
 > `clipaste-paste` and hand the printed path to the agent.
 
 ## Compatibility
+
+Local support below means a macOS or Windows clipboard host, not a native Linux
+host. SSH Ctrl+V support means a Linux consumer using the shims; macOS remotes
+use `clipaste-paste`. WSL2 always requires the Windows daemon.
 
 | Terminal | macOS Cmd+V | macOS Ctrl+V | Windows Ctrl+V | SSH Ctrl+V | WSL2 Ctrl+V |
 |----------|:-----------:|:------------:|:--------------:|:----------:|:-----------:|
@@ -210,9 +237,9 @@ reading docs. Point your agent at [AGENTS.md](AGENTS.md), or give it one command
 clipaste doctor --json
 ```
 
-It classifies the machine (`clipboard-host` / `ssh-remote` / `wsl2`), runs only
-the checks that apply there, and returns a literal `fix` command for anything
-broken:
+The role contract is `clipboard-host` / `ssh-remote` / `wsl2` / `unsupported-host`.
+It selects the applicable checks and returns remediation commands or guidance in
+`fix` where available:
 
 ```json
 {
@@ -231,6 +258,21 @@ broken:
 Exit code is `0` when usable (including warnings), `1` when broken, `2` on bad
 arguments. Every setup command is non-interactive and idempotent, so an agent
 can run them unattended.
+
+`unsupported-host` extends the role contract for an unsupported local machine
+with no WSL context, SSH session, or configured consumer helper. It reports
+`fail` with exit code `1`; its `platform` check explains the limit with `fix: null`.
+WSL detection takes precedence over SSH; actual SSH
+sessions remain `ssh-remote`, including SSH into macOS. A configured Linux
+consumer also remains `ssh-remote` when SSH environment variables are absent,
+so helper and bridge diagnostics still apply.
+
+An `unsupported-host` failure is a platform capability limit, not a missing
+systemd service, PATH entry, or `curl` dependency. Those changes cannot enable
+a Linux clipboard host. To consume another machine's clipboard, start the
+daemon on a Mac or Windows host, run `ssh-setup` there, and open a new SSH
+session to Linux; for WSL2, keep the Windows daemon running and use `wsl-setup`.
+There is no command that enables a native Linux backend.
 
 ## Managing
 
@@ -261,8 +303,9 @@ macOS screenshots place raw TIFF/PNG image data on the clipboard, but terminals 
 
 ### How do I paste clipboard images over SSH?
 
-Run `clipaste ssh-setup user@your-server` once on your local machine (add `-p PORT`
-for a non-default SSH port). It detects the remote OS, installs a lightweight
+Run `clipaste ssh-setup user@your-server` once on your local Mac or Windows
+clipboard host with its daemon running (add `-p PORT` for a non-default SSH
+port). It detects the remote OS, installs a lightweight
 xclip shim (Linux) plus a universal `clipaste-paste` helper, and configures an SSH
 tunnel. After setup, open a new SSH session:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -59,7 +59,7 @@ wsl-setup` installs the same shims inside the distro, pointed at clipaste.exe on
 ## Commands
 
 ```
-clipaste                       Run the daemon (clipboard watcher + HTTP server)
+clipaste                       Run the daemon (macOS / Windows only)
 clipaste doctor [--json]       Diagnose this machine and print the fix command
 clipaste ssh-setup user@host   Configure an SSH remote (add -p PORT for a custom SSH port)
 clipaste wsl-setup             Configure WSL2 (add --host IP to skip host auto-detection)
@@ -73,6 +73,21 @@ fetches the current clipboard image into a real file on that host and prints the
 ---
 
 ## Installing
+
+### Supported hosts and consumers
+
+The clipboard-host daemon runs on macOS and Windows only. Native Linux clipboard
+hosting is not implemented, for either Wayland or X11.
+
+| OS / context | Local clipboard-host daemon | Consumer of another host's clipboard |
+|---|---|---|
+| macOS | Supported | SSH remote via `clipaste-paste` |
+| Windows | Supported | Via WSL2 |
+| Native Linux | Not implemented | Supported over SSH via shims / `clipaste-paste` |
+| WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
+
+Linux shims fetch images from a macOS or Windows daemon; they do not own or
+watch the Linux desktop clipboard. On macOS remotes, use `clipaste-paste`.
 
 macOS (Homebrew):
 
@@ -97,11 +112,17 @@ git clone https://github.com/hqhq1025/clipaste.git
 cd clipaste && cargo build --release
 ```
 
+`cargo build` and `cargo install` on Linux remain allowed for development,
+`doctor`, and consumer setup, including WSL2 setup. Build success does not imply
+local clipboard-host support. No blanket `compile_error!` gate is used because
+the CLI tools are needed on Linux consumers.
+
 ---
 
 ## SSH remote setup, in detail
 
-Run on the machine that holds the clipboard, not on the remote:
+Run on the local Mac or Windows clipboard host with its daemon running, not on
+the Linux consumer or other remote:
 
 ```bash
 clipaste ssh-setup user@your-server
@@ -160,7 +181,7 @@ unavailable, forward the port on the Windows side with `netsh interface portprox
 
 ## Paste gestures
 
-| Tool | Local | SSH → Linux | SSH → macOS | WSL2 |
+| Tool | Local (macOS / Windows) | SSH → Linux | SSH → macOS | WSL2 |
 |---|---|---|---|---|
 | Claude Code | Ctrl+V | Ctrl+V | `clipaste-paste` | Ctrl+V |
 | Cursor CLI | Ctrl+V | Ctrl+V | `clipaste-paste` | Ctrl+V |
@@ -202,14 +223,34 @@ clipaste doctor --json
 
 Contract:
 
-- `role` is `clipboard-host`, `ssh-remote` or `wsl2`, and decides which checks run.
-  Detection order is WSL markers, then SSH variables, then platform — because a WSL distro
-  is also Linux, and an SSH session into a Mac is a remote rather than a clipboard host.
+- `role` is `clipboard-host`, `ssh-remote`, `wsl2`, or `unsupported-host`, and
+  decides which checks run. `unsupported-host` is an extension of the role
+  contract; callers must accept the additional value.
+- Detection order is WSL context, then SSH session, then a supported local
+  macOS / Windows host, then a configured consumer helper, otherwise
+  `unsupported-host`. WSL takes precedence even with SSH variables present.
+  Actual SSH sessions remain `ssh-remote`, including SSH into macOS. A configured
+  Linux consumer also stays `ssh-remote` without SSH environment variables, so
+  helper and bridge checks still run.
 - `status` is the worst of all checks: `ok`, `warn` or `fail`.
-- `checks[].fix` is a literal command, or `null`.
+- `checks[].fix` is a remediation command or guidance, or `null` when no single
+  command applies.
 - Exit code is `0` when usable (including warnings), `1` when broken, `2` on bad arguments.
 - A `warn` is not a failure. "No screenshot staged yet" is the normal state of a fresh
   install; treating it as a fault causes an agent to loop.
+
+`unsupported-host` reports `fail` with exit code `1` for a local machine whose
+clipboard-host backend is unsupported and which has no WSL context, SSH session,
+or configured consumer helper. This is a capability failure, not a missing
+systemd service, PATH entry, or `curl` dependency. Installing dependencies or
+adding a service cannot enable native Linux clipboard hosting.
+The `platform` check puts the explanation and supported setup paths in `detail`,
+with `fix: null` because no single command can add the missing backend.
+
+To consume a supported host's clipboard on Linux, start the daemon on that
+local Mac or Windows host, run `ssh-setup` there, and open a new SSH session.
+For WSL2, keep the Windows daemon running and run `wsl-setup` in the distro.
+No command enables a native Linux backend.
 
 Checks distinguish failure modes that look identical from outside: helper missing, helper
 installed but not on PATH, shim shadowed by the real `xclip`, tunnel down, and a stale
@@ -228,9 +269,10 @@ Terminals on the clipboard host: Ghostty, Alacritty, iTerm2, Terminal.app, WezTe
 Kitty on macOS; Windows Terminal, PowerShell and cmd.exe on Windows. WezTerm and Kitty
 also cover Windows Ctrl+V.
 
-Remotes: any Linux server reachable over SSH that has `curl`. WSL2 distros including
-Ubuntu, Debian, Fedora, Arch and Kali. macOS remotes are supported through
-`clipaste-paste`.
+Consumers: Linux servers reachable over SSH with `curl`, backed by a macOS or
+Windows clipboard host. WSL2 distros including Ubuntu, Debian, Fedora, Arch and
+Kali require the Windows daemon. macOS remotes are supported through
+`clipaste-paste`. Native Linux clipboard hosting is not implemented.
 
 ---
 
@@ -276,15 +318,17 @@ arrives empty. clipaste writes the screenshot to a temp PNG and puts that path o
 clipboard alongside the image data.
 
 **Can I paste screenshots into Claude Code running on a remote server over SSH?**
-Yes. Run `clipaste ssh-setup user@host` from the machine holding the clipboard, then open a
-new SSH session and press Ctrl+V.
+Yes. Run `clipaste ssh-setup user@host` from the local Mac or Windows clipboard
+host with its daemon running, then open a new SSH session. On Linux remotes,
+press Ctrl+V in Claude Code; on macOS remotes, use `clipaste-paste`.
 
 **Why can't Codex CLI paste images over SSH the way Claude Code can?**
 Codex reads the clipboard in-process via `arboard` and never runs `xclip`, so it bypasses
 the shim. Use `clipaste-paste` on the remote and hand the printed path to Codex.
 
 **Does clipaste work in WSL2?**
-Yes, in both mirrored and NAT networking modes. Run `clipaste wsl-setup` inside the distro.
+Yes, with the Windows daemon already running. Run `clipaste wsl-setup` inside
+the distro; see the networking requirements above.
 
 **How much memory and CPU does clipaste use?**
 About 9 MB resident and no measurable idle CPU.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -18,15 +18,30 @@ the picture rather than a meaningless path.
 
 ## Install
 
+The clipboard-host daemon supports macOS and Windows only. Native Linux clipboard
+hosting is not implemented on either Wayland or X11.
+
+| OS / context | Local clipboard-host daemon | Consumer of another host's clipboard |
+|---|---|---|
+| macOS | Supported | SSH remote via `clipaste-paste` |
+| Windows | Supported | Via WSL2 |
+| Native Linux | Not implemented | Supported over SSH via shims / `clipaste-paste` |
+| WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
+
 - macOS: `brew install hqhq1025/clipaste/clipaste && brew services start clipaste`
 - Windows: `irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex`
 - Verify: `clipaste doctor` (add `--json` for machine-readable output)
-- SSH remote: `clipaste ssh-setup user@host` — run this on the machine holding the clipboard
+- SSH remote: `clipaste ssh-setup user@host`, run on the local Mac or Windows clipboard host with its daemon running
 - WSL2: `clipaste wsl-setup` — run this inside the distro, with clipaste.exe running on Windows
+
+Linux `cargo build` and `cargo install` remain allowed for development, `doctor`,
+and consumer setup. They do not enable a local Linux daemon. A blanket
+`compile_error!` gate would also block these needed CLI tools. Linux shims consume
+images from the supported host; they do not watch the Linux clipboard.
 
 ## Paste gesture by tool and location
 
-| Tool | Local | SSH → Linux | SSH → macOS | WSL2 |
+| Tool | Local (macOS / Windows) | SSH → Linux | SSH → macOS | WSL2 |
 |---|---|---|---|---|
 | Claude Code | Ctrl+V | Ctrl+V | `clipaste-paste` | Ctrl+V |
 | Cursor CLI | Ctrl+V | Ctrl+V | `clipaste-paste` | Ctrl+V |
@@ -41,11 +56,24 @@ Never press Cmd+V inside an SSH session — it sends the local file path as text
 
 ## For coding agents
 
-`clipaste doctor --json` is the machine-readable entry point. It classifies the machine
-as `clipboard-host`, `ssh-remote` or `wsl2`, runs only the checks meaningful for that
-role, and returns each check as `{name, status, detail, fix}` where `fix` is a literal
-command. Exit code: 0 usable (including warnings), 1 broken, 2 bad arguments. All setup
+`clipaste doctor --json` is the machine-readable entry point. Its role contract is
+`clipboard-host`, `ssh-remote`, `wsl2`, or `unsupported-host`. Each check is
+`{name, status, detail, fix}`; `fix` is a remediation command, guidance, or `null`.
+Exit code: 0 usable (including warnings), 1 broken, 2 bad arguments. All setup
 commands are non-interactive and idempotent.
+
+The `unsupported-host` extension reports `fail` (exit 1) for an unsupported local
+machine without WSL context, an SSH session, or a configured consumer helper.
+Its `platform` check gives guidance in `detail` with `fix: null`.
+WSL takes precedence over SSH. Actual SSH sessions, including SSH into macOS,
+remain `ssh-remote`; a configured Linux consumer also retains `ssh-remote` when
+SSH environment variables are absent.
+
+`unsupported-host` is a capability failure, not a missing systemd service, PATH
+entry, or `curl` dependency. To use Linux as a consumer, run `ssh-setup` on the
+Mac or Windows clipboard host with its daemon running, then open a new SSH
+session. WSL2 requires the Windows daemon and `wsl-setup` inside the distro.
+No command enables a native Linux clipboard backend.
 
 ## Key facts
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,6 +11,22 @@ use std::time::SystemTime;
 pub const VERSION: &str = "2.4.2";
 pub const DEFAULT_PORT: u16 = 18340;
 
+pub fn supports_clipboard_host(os: &str) -> bool {
+    matches!(os, "macos" | "windows")
+}
+
+pub fn unsupported_host_message(os: &str) -> String {
+    let name = if os == "linux" { "Linux" } else { os };
+    format!(
+        "{name} clipboard host is not supported. The daemon requires macOS or Windows.\n\
+         Linux is supported as an SSH consumer: run `clipaste ssh-setup user@host` on \
+         the macOS/Windows clipboard host, then use `clipaste-paste` on the remote.\n\
+         In WSL2, run `clipaste wsl-setup` with clipaste.exe running on Windows.\n\
+         Installing the Rust binary does not add a Linux clipboard backend.\n\
+         See https://github.com/hqhq1025/clipaste#supported-platforms"
+    )
+}
+
 /// Shared state: path to the most recently saved screenshot PNG
 pub type LatestImage = Arc<Mutex<Option<PathBuf>>>;
 
@@ -406,7 +422,7 @@ pub fn print_help() {
         "clipaste v{VERSION} — Fix screenshot paste in terminals (local + SSH + WSL2)
 
 USAGE
-  clipaste                       Run daemon (clipboard watcher + HTTP server)
+  clipaste                       Run daemon (macOS/Windows clipboard host only)
   clipaste doctor [--json]       Diagnose this machine and print the fix command
   clipaste ssh-setup user@host   Configure remote server for image paste via SSH
                                  (add -p PORT for a custom SSH port)
@@ -440,10 +456,14 @@ WHAT IT DOES
           networking modes both work); override it with --host IP if needed.
 
 COMPATIBILITY
+  Host:    macOS and Windows only; native Linux clipboard hosts are unsupported
   macOS:   Ghostty, Alacritty, iTerm2, Terminal.app, WezTerm, Kitty
   Windows: Windows Terminal, PowerShell, cmd.exe
-  Remote:  Any Linux server via SSH
-  WSL2:    Ubuntu, Debian, Fedora, Arch on WSL2
+  Remote:  Linux and macOS via SSH from a macOS/Windows clipboard host
+  WSL2:    Consumer only; requires clipaste.exe running on Windows
+
+  Building/installing this binary on Linux provides doctor and setup commands,
+  not a local clipboard watcher. Run ssh-setup on the macOS/Windows host.
 
 MORE INFO
   https://github.com/hqhq1025/clipaste"

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -76,6 +76,8 @@ pub enum Role {
     SshRemote,
     /// A WSL2 distro; fetches from clipaste.exe on the Windows host.
     Wsl2,
+    /// No local clipboard backend and no evidence of a configured consumer.
+    UnsupportedHost,
 }
 
 impl Role {
@@ -84,29 +86,41 @@ impl Role {
             Role::ClipboardHost => "clipboard-host",
             Role::SshRemote => "ssh-remote",
             Role::Wsl2 => "wsl2",
+            Role::UnsupportedHost => "unsupported-host",
         }
     }
 }
 
 /// Classify the current machine.
 ///
-/// Order matters. WSL2 is checked first because a WSL distro is also Linux and
+/// Order matters. WSL2 is checked first on Linux because a WSL distro
 /// may also carry SSH variables; SSH is checked before the platform default
 /// because an SSH'd-into Mac is a *remote*, not a clipboard host — that
 /// distinction is exactly what issue #2 turned on.
 pub fn detect_role() -> Role {
-    if is_wsl() {
+    classify_role(
+        std::env::consts::OS,
+        is_wsl(),
+        is_ssh_session(),
+        installed_helper_url(&home().join(".local/bin/clipaste-paste")).is_some(),
+    )
+}
+
+fn classify_role(os: &str, wsl: bool, ssh: bool, configured_consumer: bool) -> Role {
+    if os == "linux" && wsl {
         return Role::Wsl2;
     }
-    if is_ssh_session() {
+    if ssh {
         return Role::SshRemote;
     }
-    if cfg!(any(target_os = "macos", target_os = "windows")) {
+    if common::supports_clipboard_host(os) {
         Role::ClipboardHost
-    } else {
-        // Plain Linux with no SSH variables: it has no clipaste daemon of its
-        // own, so it can only ever be the consuming side.
+    } else if configured_consumer {
+        // A configured Linux consumer may be used outside the original SSH
+        // session (for example from tmux); let bridge checks diagnose its tunnel.
         Role::SshRemote
+    } else {
+        Role::UnsupportedHost
     }
 }
 
@@ -247,7 +261,19 @@ pub fn run(json: bool) -> i32 {
 }
 
 fn diagnose() -> Report {
-    let role = detect_role();
+    diagnose_role(detect_role())
+}
+
+fn diagnose_role(role: Role) -> Report {
+    if role == Role::UnsupportedHost {
+        return Report {
+            role,
+            checks: vec![Check::fail(
+                "platform",
+                common::unsupported_host_message(std::env::consts::OS),
+            )],
+        };
+    }
     let mut checks = Vec::new();
 
     if which("curl").is_none() {
@@ -261,6 +287,7 @@ fn diagnose() -> Report {
         Role::ClipboardHost => checks.extend(clipboard_host_checks()),
         Role::SshRemote => checks.extend(consumer_checks(Role::SshRemote)),
         Role::Wsl2 => checks.extend(consumer_checks(Role::Wsl2)),
+        Role::UnsupportedHost => unreachable!("unsupported host returned above"),
     }
 
     Report { role, checks }
@@ -489,6 +516,9 @@ fn render_human(r: &Report) -> String {
     out.push_str(match r.worst() {
         Status::Ok => "All good.\n",
         Status::Warn => "Usable, with warnings above.\n",
+        Status::Fail if r.role == Role::UnsupportedHost => {
+            "Local clipboard hosting is unavailable on this platform; see the supported roles above.\n"
+        }
         Status::Fail => "Not working — run the → commands above.\n",
     });
     out
@@ -527,6 +557,40 @@ fn render_json(r: &Report) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_linux_is_not_assumed_to_be_an_ssh_remote() {
+        assert_eq!(
+            classify_role("linux", false, false, false),
+            Role::UnsupportedHost
+        );
+    }
+
+    #[test]
+    fn role_detection_preserves_existing_consumers_and_supported_hosts() {
+        assert_eq!(classify_role("linux", false, true, false), Role::SshRemote);
+        assert_eq!(classify_role("linux", false, false, true), Role::SshRemote);
+        assert_eq!(classify_role("linux", true, true, true), Role::Wsl2);
+        assert_eq!(classify_role("macos", false, true, true), Role::SshRemote);
+        assert_eq!(classify_role("macos", false, false, true), Role::ClipboardHost);
+        assert_eq!(classify_role("windows", true, false, true), Role::ClipboardHost);
+    }
+
+    #[test]
+    fn unsupported_host_reports_capability_without_install_or_network_checks() {
+        let report = diagnose_role(Role::UnsupportedHost);
+        assert_eq!(report.exit_code(), 1);
+        assert_eq!(report.checks.len(), 1);
+        assert_eq!(report.checks[0].name, "platform");
+        assert!(report.checks[0].fix.is_none());
+        let json = render_json(&report);
+        assert!(json.contains("\"role\":\"unsupported-host\""));
+        assert!(json.contains("\"status\":\"fail\""));
+        assert!(json.contains("macOS or Windows"));
+        let human = render_human(&report);
+        assert!(human.contains("clipaste ssh-setup"));
+        assert!(!human.contains("run the → commands"));
+    }
 
     #[test]
     fn parses_helper_url() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod common;
 mod doctor;
-mod server;
-mod ssh_setup;
 #[cfg(target_os = "macos")]
 mod macos;
+mod server;
+mod ssh_setup;
 #[cfg(target_os = "windows")]
 mod windows;
 
@@ -22,7 +22,10 @@ fn main() {
     // clipaste ssh-setup [-p PORT] user@host [-p PORT]
     if args.len() >= 3 && args[1] == "ssh-setup" {
         match parse_ssh_setup_args(&args[2..]) {
-            Ok((host, ssh_port)) => ssh_setup::run_ssh(&host, ssh_port),
+            Ok((host, ssh_port)) => {
+                require_clipboard_host();
+                ssh_setup::run_ssh(&host, ssh_port);
+            }
             Err(e) => {
                 eprintln!("clipaste ssh-setup: {e}");
                 eprintln!("usage: clipaste ssh-setup [-p PORT] user@host");
@@ -56,6 +59,9 @@ fn main() {
         std::process::exit(doctor::run(json));
     }
 
+    // Reject unsupported hosts before starting a listener or touching the cache.
+    require_clipboard_host();
+
     // Start HTTP server for remote access
     let latest = common::LatestImage::default();
     server::start(latest.clone());
@@ -66,10 +72,12 @@ fn main() {
 
     #[cfg(target_os = "windows")]
     windows::run(latest);
+}
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        eprintln!("clipaste: unsupported platform");
+fn require_clipboard_host() {
+    let os = std::env::consts::OS;
+    if !common::supports_clipboard_host(os) {
+        eprintln!("clipaste: {}", common::unsupported_host_message(os));
         std::process::exit(1);
     }
 }
@@ -100,14 +108,20 @@ fn parse_ssh_setup_args(args: &[String]) -> Result<(String, Option<u16>), String
             continue;
         }
         if let Some(rest) = a.strip_prefix("--port=") {
-            ssh_port = Some(rest.parse::<u16>().map_err(|_| format!("invalid port: {rest}"))?);
+            ssh_port = Some(
+                rest.parse::<u16>()
+                    .map_err(|_| format!("invalid port: {rest}"))?,
+            );
             i += 1;
             continue;
         }
         if let Some(rest) = a.strip_prefix("-p") {
             // -p22222 (attached form)
             if !rest.is_empty() {
-                ssh_port = Some(rest.parse::<u16>().map_err(|_| format!("invalid port: {rest}"))?);
+                ssh_port = Some(
+                    rest.parse::<u16>()
+                        .map_err(|_| format!("invalid port: {rest}"))?,
+                );
                 i += 1;
                 continue;
             }

--- a/tests/linux_cli.rs
+++ b/tests/linux_cli.rs
@@ -1,0 +1,236 @@
+#![cfg(target_os = "linux")]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+struct TestHome(PathBuf);
+
+impl TestHome {
+    fn new() -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        loop {
+            let path = std::env::temp_dir().join(format!(
+                "clipaste-linux-cli-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            match fs::create_dir(&path) {
+                Ok(()) => return Self(path),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => panic!("{e}"),
+            }
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_clipaste"));
+        // No inherited SSH/WSL variables or curl/ssh executables. These tests
+        // must not contact a daemon or alter the real user's configuration.
+        cmd.env_clear()
+            .env("HOME", &self.0)
+            .env("PATH", &self.0)
+            .env("XDG_CACHE_HOME", self.0.join("cache"))
+            .current_dir(&self.0);
+        cmd
+    }
+
+    fn script(&self, name: &str, content: &str) {
+        let path = self.0.join(name);
+        fs::write(&path, content).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(Command::new("/bin/sh")
+            .arg("-n")
+            .arg(path)
+            .status()
+            .unwrap()
+            .success());
+    }
+
+    fn fake_curl(&self) {
+        self.script(
+            "curl",
+            "#!/bin/sh\n\
+             printf '%s\\n' \"$@\" >> \"$HOME/curl-args\"\n\
+             if [ \"$CLIPASTE_TEST_CURL_FAIL\" = 1 ]; then exit 22; fi\n\
+             printf '%s' '{\"status\":\"ok\",\"version\":\"test\"}'\n",
+        );
+    }
+}
+
+impl Drop for TestHome {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8(out.stdout.clone()).unwrap()
+}
+
+fn wsl_kernel() -> bool {
+    let kernel = fs::read_to_string("/proc/sys/kernel/osrelease")
+        .unwrap()
+        .to_lowercase();
+    kernel.contains("microsoft") || kernel.contains("wsl")
+}
+
+#[test]
+fn unsupported_daemon_and_host_setup_fail_before_side_effects() {
+    let home = TestHome::new();
+    for args in [vec![], vec!["ssh-setup", "user@example.invalid"]] {
+        let out = home.command().args(args).output().unwrap();
+        assert_eq!(out.status.code(), Some(1));
+        assert!(out.stdout.is_empty());
+        let error = String::from_utf8(out.stderr).unwrap();
+        assert!(error.contains("Linux clipboard host is not supported"));
+        assert!(error.contains("macOS or Windows"));
+        assert!(error.contains("clipaste-paste"));
+        assert!(!error.contains("http server"));
+        assert!(!error.contains("brew services start"));
+        assert_eq!(fs::read_dir(&home.0).unwrap().count(), 0);
+    }
+}
+
+#[test]
+fn native_linux_or_wsl_doctor_reports_the_applicable_failure() {
+    let home = TestHome::new();
+    let out = home.command().args(["doctor", "--json"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let json = stdout(&out);
+    assert!(json.contains("\"status\":\"fail\""));
+    // Clearing environment variables cannot change a real WSL kernel.
+    if wsl_kernel() {
+        assert!(json.contains("\"role\":\"wsl2\""));
+        assert!(json.contains("\"name\":\"helper\""));
+        assert!(!json.contains("\"name\":\"platform\""));
+    } else {
+        assert!(json.contains("\"role\":\"unsupported-host\""));
+        assert!(json.contains("\"name\":\"platform\""));
+        assert!(json.contains("\"fix\":null"));
+        assert!(!json.contains("\"name\":\"curl\""));
+        assert!(!json.contains("\"name\":\"helper\""));
+    }
+    assert_eq!(fs::read_dir(&home.0).unwrap().count(), 0);
+}
+
+#[test]
+fn ssh_and_wsl_consumers_keep_their_existing_diagnostic_paths() {
+    let home = TestHome::new();
+    for (var, value, role) in [
+        (
+            "SSH_CONNECTION",
+            "192.0.2.1 1234 192.0.2.2 22",
+            "ssh-remote",
+        ),
+        ("WSL_DISTRO_NAME", "Ubuntu", "wsl2"),
+    ] {
+        let out = home
+            .command()
+            .env(var, value)
+            .args(["doctor", "--json"])
+            .output()
+            .unwrap();
+        assert_eq!(out.status.code(), Some(1));
+        let json = stdout(&out);
+        let expected_role = if wsl_kernel() { "wsl2" } else { role };
+        assert!(json.contains(&format!("\"role\":\"{expected_role}\"")));
+        assert!(json.contains("\"name\":\"helper\""));
+        assert!(!json.contains("\"name\":\"platform\""));
+    }
+}
+
+#[test]
+fn configured_consumer_without_ssh_variables_is_still_diagnosed() {
+    let home = TestHome::new();
+    let bin = home.0.join(".local/bin");
+    fs::create_dir_all(&bin).unwrap();
+    // Intentionally non-executable, so consumer checks stop before HTTP probes.
+    fs::write(
+        bin.join("clipaste-paste"),
+        "CLIPASTE_URL=\"http://127.0.0.1:18340\"\n",
+    )
+    .unwrap();
+    let out = home.command().args(["doctor", "--json"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let role = if wsl_kernel() { "wsl2" } else { "ssh-remote" };
+    assert!(stdout(&out).contains(&format!("\"role\":\"{role}\"")));
+    assert!(stdout(&out).contains("\"name\":\"helper\""));
+}
+
+#[test]
+fn configured_consumer_checks_its_bridge_without_real_network_access() {
+    let home = TestHome::new();
+    let bin = home.0.join(".local/bin");
+    fs::create_dir_all(&bin).unwrap();
+    home.script(
+        ".local/bin/clipaste-paste",
+        "#!/bin/sh\nCLIPASTE_URL=\"http://127.0.0.1:18444\"\nexit 0\n",
+    );
+    home.fake_curl();
+    let path = std::env::join_paths([&bin, &home.0]).unwrap();
+    for (failure, code, bridge_status) in [("0", 0, "ok"), ("1", 1, "fail")] {
+        let out = home
+            .command()
+            .env("PATH", &path)
+            .env("CLIPASTE_TEST_CURL_FAIL", failure)
+            .args(["doctor", "--json"])
+            .output()
+            .unwrap();
+        assert_eq!(out.status.code(), Some(code));
+        assert!(stdout(&out).contains(&format!(
+            "\"name\":\"bridge\",\"status\":\"{bridge_status}\""
+        )));
+        assert!(!stdout(&out).contains("\"name\":\"platform\""));
+    }
+    let args = fs::read_to_string(home.0.join("curl-args")).unwrap();
+    assert_eq!(args.matches("http://127.0.0.1:18444/health").count(), 2);
+}
+
+#[test]
+fn valid_wsl_setup_still_installs_consumer_helpers() {
+    let home = TestHome::new();
+    home.fake_curl();
+    let out = home
+        .command()
+        .env("WSL_DISTRO_NAME", "Ubuntu")
+        .args(["wsl-setup", "--host", "127.0.0.1"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+    for name in ["clipaste-paste", "xclip", "wl-paste"] {
+        let path = home.0.join(".local/bin").join(name);
+        assert!(fs::read_to_string(&path)
+            .unwrap()
+            .contains("http://127.0.0.1:18340"));
+        assert_ne!(fs::metadata(path).unwrap().permissions().mode() & 0o111, 0);
+    }
+    assert!(home.0.join(".bashrc").is_file());
+    assert!(fs::read_to_string(home.0.join("curl-args"))
+        .unwrap()
+        .contains("/health"));
+}
+
+#[test]
+fn help_version_and_consumer_argument_validation_remain_available() {
+    let home = TestHome::new();
+    for flag in ["--help", "--version"] {
+        let out = home.command().arg(flag).output().unwrap();
+        assert!(out.status.success());
+        if flag == "--help" {
+            assert!(stdout(&out).contains("native Linux clipboard hosts are unsupported"));
+            assert!(stdout(&out).contains("wsl-setup"));
+        }
+    }
+    let out = home
+        .command()
+        .args(["wsl-setup", "--bad-option"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let error = String::from_utf8(out.stderr).unwrap();
+    assert!(error.contains("unexpected argument"));
+    assert!(!error.contains("clipboard host is not supported"));
+}


### PR DESCRIPTION
## Summary

Addresses the near-term documentation / actionable-failure option explicitly requested in #9. This does not implement a Linux clipboard-host backend.

- Publish an explicit macOS / Windows / native Linux / WSL2 host-versus-consumer matrix in the README, agent instructions, and LLM-facing docs.
- Reject daemon startup on unsupported hosts before starting the HTTP server; reject host-side ssh-setup before checking or changing anything.
- Explain that Linux compilation provides diagnostic and consumer setup commands, not a Wayland/X11 clipboard watcher. Keep those commands buildable and usable.
- Add the doctor role `unsupported-host` with a single failing platform check and `fix: null`, while preserving WSL precedence, actual SSH sessions, and configured Linux consumers without SSH variables.
- Add isolated Linux process-level tests for CLI errors, role classification, mocked bridge success/failure, and successful WSL helper installation. Add Linux/macOS/Windows CI.

## Validation

- Reproduced the native-Linux-as-SSH-remote misclassification in a failing regression test before changing the decision logic.
- macOS: 67 unit tests passed; strict Clippy passed.
- Windows MSVC cross-target strict Clippy passed.
- Linux cross-target Clippy passed with existing unused image/cache warnings; actual Linux execution is covered by the new CI job.
- Tests use temporary homes and fake curl responses; they do not contact a daemon, modify the real home directory, or touch the general clipboard.

## Scope and compatibility

This extends the doctor JSON role enum; consumers should accept `unsupported-host`. Native Linux hosting remains unsupported and would need a separately designed Wayland/X11 backend. Keeping #9 linked rather than auto-closing it allows that feature discussion to remain explicit. No release tag or published artifact is changed.