### PR TITLE
Add Linux clipboard hosts with Wayland and X11 backends

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,3 +19,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --locked
       - run: cargo clippy --locked --all-targets
+
+  linux-desktop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install isolated desktop test dependencies
+        run: sudo apt-get update && sudo apt-get install -y xvfb xclip sway wl-clipboard dbus-x11 python3-pil
+      - name: Exercise real X11 and Wayland selections
+        run: bash tests/linux/run.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@ Instructions for coding agents working with clipaste — both **installing it fo
 user** and **contributing to this repository**.
 
 clipaste is a clipboard daemon that makes screenshot paste work in terminal AI
-tools (Claude Code, Codex CLI, Cursor CLI), locally and across SSH/WSL2
-boundaries.
+tools (Claude Code, Codex CLI, Cursor CLI), locally on macOS/Windows and across
+SSH/WSL2 boundaries. Graphical Linux hosts provide read-only PNG clipboard
+capture for the SSH bridge.
 
 ---
 
@@ -56,10 +57,10 @@ A `warn` is not a failure. "No screenshot on the clipboard yet" is the normal
 state of a freshly installed machine — do not report it to the user as a
 problem, and do not try to fix it.
 
-`unsupported-host` is an extension of the role contract. Consumers of the JSON
-output must accept it and treat its `fail` status (exit code `1`) as a platform
-capability limit, not as a missing service or dependency. Its `platform` check
-provides guidance in `detail` with `fix: null`.
+Consumers of the JSON output must accept `unsupported-host` for platforms
+without a backend. Do not apply it to Linux as a whole: Linux host diagnostics
+must distinguish missing tools, missing session access, and missing compositor
+data-control from consumer helper or bridge failures.
 
 ### Decide where you are before installing anything
 
@@ -70,18 +71,21 @@ single most common mistake.
 |---|---|---|
 | macOS | Supported | SSH remote via `clipaste-paste` |
 | Windows | Supported | Via WSL2 |
-| Native Linux | Not implemented, on Wayland or X11 | Supported over SSH via shims / `clipaste-paste` |
+| Native Linux desktop | Read-only `image/png` via Wayland data-control or X11/XWayland | Supported over SSH via shims / `clipaste-paste` |
+| Headless Linux | No display; host startup fails with guidance | Supported with configured helpers / SSH |
 | WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
 
-```
-        the machine holding the clipboard          the machine running the agent
-        (where you press Cmd+Shift+4)              (where Claude Code runs)
-        ─────────────────────────────              ─────────────────────────────
-              macOS / Windows            ──HTTP──►      same machine
-                                                        SSH remote
-              runs the daemon                            WSL2 distro
-              install: brew / install.ps1                install: run setup FROM the
-                                                         clipboard host, not here
+```text
+Clipboard host                              Consumer
+macOS / Windows / graphical Linux
+  PNG cache -> loopback HTTP -> SSH tunnel -> SSH remote
+  run ssh-setup on this host                 shims / clipaste-paste
+
+Windows -> HTTP over WSL networking -------> WSL2
+  Windows daemon                            run wsl-setup inside the distro
+
+Local macOS / Windows: existing clipboard normalization and paste
+Local Linux: read-only PNG capture, no added text-path paste
 ```
 
 `clipaste doctor --json` reports which side you are on as `role`. Trust it over
@@ -91,12 +95,17 @@ The role contract applies in this order:
 
 1. WSL context: `wsl2`, even if SSH environment variables are also present.
 2. An actual SSH session: `ssh-remote`, including SSH into macOS.
-3. A local macOS or Windows machine: `clipboard-host`.
-4. A machine without a local backend but with a configured consumer helper:
-   `ssh-remote`. This includes Linux consumers without SSH environment variables;
-   keep checking their helper and bridge.
-5. An unsupported local machine without those consumer indicators:
-   `unsupported-host`.
+3. A local macOS or Windows machine, or graphical local Linux session:
+   `clipboard-host`. Linux backend access still needs validation.
+4. A headless Linux machine with a configured consumer helper: `ssh-remote`,
+   even without SSH environment variables; keep checking its helper and bridge.
+5. Linux without a display or consumer indicators: `clipboard-host` with a
+   failing `backend` check and actionable graphical-session guidance. Other
+   platforms without a backend or consumer indicators retain `unsupported-host`.
+
+WSL remains a Windows consumer even when WSLg supplies display variables. SSH
+session detection takes precedence over a Linux desktop's display variables.
+Do not reclassify those consumers as hosts.
 
 ### Install on the clipboard host
 
@@ -115,23 +124,76 @@ irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex
 clipaste doctor --json
 ```
 
-From source:
+Linux desktop (Rust/Cargo required; Ubuntu package example):
 
 ```bash
+sudo apt install wl-clipboard xclip curl
 git clone https://github.com/hqhq1025/clipaste.git
-cd clipaste && cargo build --release
+cd clipaste
+cargo install --path .
+clipaste
 ```
 
-Linux `cargo build` and `cargo install` remain allowed for development, `doctor`,
-and consumer setup, including `wsl-setup`. Successful compilation does not
-provide a Linux clipboard-host daemon. Do not add a blanket `compile_error!`
-gate: the CLI tools are still needed on Linux consumers.
+Ensure Cargo's binary directory (normally `~/.cargo/bin`) is on `PATH`. Start
+`clipaste` as the desktop user in a graphical-session terminal and leave it
+running. No Linux service or auto-start entry is installed. In a separate
+terminal from that same session, run:
+
+```bash
+clipaste doctor --json
+clipaste ssh-setup user@host
+```
+
+For development, `cargo build --release` works from the checkout. Linux retains
+`doctor` and consumer setup, including `wsl-setup`; do not add a blanket
+`compile_error!` gate that blocks consumer machines.
+
+### Linux backend and verification contract
+
+- `CLIPASTE_BACKEND=auto` is the default. Prefer real system `wl-paste` with
+  usable data-control access; otherwise warn and use system `xclip` through an
+  accessible `DISPLAY`, or fail with actionable guidance if unavailable.
+  HTTP consumer shims do not count as system clipboard tools.
+- Native Wayland requires `wl-clipboard >=2.2` for empty-selection watch events.
+  All Wayland clipboard accesses use `wl-paste --watch` in bounded one-shot mode,
+  which refuses popup fallback and verifies actual compiled-in data-control
+  support. Ext-only compositors need `wl-clipboard >=2.3` built with
+  `ext-data-control` support; `wlr-data-control` works with compatible 2.2+
+  builds. Version 2.1.x triggers the `auto` XWayland fallback or fails without
+  `DISPLAY`; a version number alone does not establish protocol support.
+- `CLIPASTE_BACKEND=wayland` requires native data-control access and fails
+  instead of falling back. `CLIPASTE_BACKEND=x11` requires `xclip` and an
+  accessible `DISPLAY`. Use the same override for the daemon and `doctor`.
+- Run host diagnostics as the same desktop user and in the same session.
+  Wayland needs `WAYLAND_DISPLAY` and `XDG_RUNTIME_DIR`; X11/XWayland needs
+  `DISPLAY` and display authorization. SSH, `sudo`, stale tmux environments,
+  and services can lack that context. Setting a variable alone does not
+  establish display access.
+- No display produces actionable guidance to start from a graphical desktop or
+  configure a consumer. Wayland-only sessions without data-control must fail
+  with guidance to use XWayland (`xclip` + `DISPLAY`) or an X11 session. Never
+  use focus-stealing windows or arbitrary forced-focus Wayland polling.
+- GNOME Wayland may require its XWayland clipboard bridge. Require reporters
+  to copy a screenshot from a native Wayland app, re-run `doctor`, then verify
+  the image fetched on the remote with `clipaste-paste`. An X11-only test is
+  insufficient, and a backend probe is not universal compatibility evidence.
+- Linux polls every 300 ms and reads `image/png` without modifying the
+  clipboard. It saves to the private stable PNG cache, then serves through
+  existing loopback HTTP and SSH shims / `clipaste-paste`. It does not add
+  file URLs or text, and does not promise local terminal text-path paste.
+  Image file-copy offering only a URI is not supported yet.
+- Clipboard clears, non-image content, and recognized private markers clear
+  the staged image. Historical cache paths remain; this is not cache erasure.
+  Keep cache directories `0700` and files `0600`, with no automatic expiry.
+- Preserve existing macOS/Windows clipboard normalization and paste workflows.
+  Linux tests do not establish macOS/Windows regression coverage or universal
+  desktop compatibility; report exactly which platforms were verified.
 
 ### Wire up an SSH remote
 
-Run this on the local macOS or Windows clipboard host, not on the Linux
-consumer or other remote. It needs the local daemon running, and it edits the
-local `~/.ssh/config`.
+Run this on the local macOS, Windows, or graphical Linux clipboard host, not on
+the remote consumer. It needs the local daemon running, and it edits the local
+`~/.ssh/config`.
 
 ```bash
 clipaste ssh-setup user@host             # non-interactive; idempotent
@@ -177,27 +239,31 @@ Codex CLI reads the clipboard in-process (via `arboard`) and never shells out to
 `xclip`, so it cannot use the shim. `clipaste-paste` writes the image to a real
 file on the current host and prints the path — hand that path to the tool.
 
+The local shortcut row does not apply to Linux hosts. Linux serves clipboard
+PNG images to remote consumers without inserting a local text path.
+
 Never tell a user to press `Cmd+V` in an SSH session: that sends the *local*
 file path as text, which the remote agent cannot open.
 
 ### Things not to do
 
-- Do not try to fix `unsupported-host` by adding a systemd service, changing
-  PATH, or installing `curl`. Native Linux clipboard hosting is not implemented;
-  the shims only fetch images from a macOS or Windows daemon. For a Linux
-  consumer, run `ssh-setup` on that supported clipboard host and reconnect.
-  For WSL2, require the Windows daemon and run `wsl-setup` inside the distro.
-- Do not classify all Linux machines as `unsupported-host`: actual SSH sessions
-  and configured Linux consumers retain `ssh-remote` diagnostics.
+- Do not install a Linux systemd service automatically or present it as a fix
+  for missing desktop access. Follow the reported tool/session/data-control
+  guidance. For a consumer, run `ssh-setup` on its clipboard host and reconnect;
+  WSL2 still requires the Windows daemon and `wsl-setup` inside the distro.
+- Do not classify all Linux machines as hosts or as `unsupported-host`: actual
+  SSH sessions and configured headless consumers retain `ssh-remote` diagnostics.
 - Do not bind the daemon to `0.0.0.0` or add firewall exceptions to "fix"
   connectivity. It listens on loopback deliberately; the image bytes on that
   port are the user's screen contents.
 - Do not write shims by hand. `ssh-setup` / `wsl-setup` generate them with the
   correct URL baked in; a hand-written one drifts silently.
 - Do not `kill -9` the daemon to restart it. Use `brew services restart clipaste`
-  (macOS) or stop `clipaste.exe` normally (Windows).
+  (macOS), stop `clipaste.exe` normally (Windows), or Ctrl+C in its graphical
+  terminal (Linux).
 - Do not report success without a passing `clipaste doctor`. "The install
-  command exited 0" is not the same as "paste works".
+  command exited 0" is not the same as "paste works". On Linux, also verify a
+  real screenshot end to end, especially when XWayland fallback is reported.
 
 ---
 
@@ -212,6 +278,7 @@ src/
 ├── server.rs      HTTP server on 127.0.0.1:18340 (/health, /clipboard/type, /clipboard/image)
 ├── doctor.rs      environment classification + checks + human/JSON rendering
 ├── ssh_setup.rs   shim templates, ssh-setup, wsl-setup, host detection
+├── linux.rs       read-only PNG polling via system wl-paste / xclip (cfg linux)
 ├── macos.rs       NSPasteboard watcher (cfg macos)
 └── windows.rs     clipboard-format listener (cfg windows)
 ```
@@ -224,14 +291,39 @@ cargo test          # must stay green; no network access required
 cargo clippy --all-targets
 ```
 
-Tests run without a daemon, without a network, and without touching the real
-`$HOME`. Keep it that way — anything that needs a home directory must take one
-via an env override, as `remote_script_run_installs_into_empty_home` does.
+The default `cargo test` suite runs without a daemon, without a network, and
+without touching the real `$HOME`. Keep that default isolated; anything that
+needs a home directory must take one via an env override, as
+`remote_script_run_installs_into_empty_home` does.
+
+Opt-in Linux desktop integration tests use real clipboard tools in isolated
+Xvfb and headless Sway sessions, with temporary HOME/cache/runtime directories.
+They do not use the real user's clipboard. From the repository root on Linux,
+with Rust/Cargo, Clippy, and loopback port `18340` free:
+
+```bash
+sudo apt install xvfb xclip sway wl-clipboard dbus-x11 python3-pil curl
+bash tests/linux/run.sh
+```
+
+The Sway tests require `wl-clipboard >=2.2`; upgrade older distro packages first.
+The runner executes unit tests, strict Clippy, and clipboard/HTTP smoke tests.
+Alternatively, the existing container recipe builds wl-clipboard 2.3.0; run it
+without mounting desktop sockets or the user's home:
+
+```bash
+docker build -f tests/linux/Dockerfile -t clipaste-linux-test .
+docker run --rm clipaste-linux-test
+```
+
+Isolated Xvfb/Sway coverage does not establish compatibility with GNOME,
+ext-only compositors, or the reporter's native application.
 
 ### Conventions this codebase holds to
 
 - **No new dependencies without a strong reason.** The point of clipaste is that
-  it is 9 MB of RAM and a handful of syscalls. HTTP is `curl`; JSON output is
+  it stays lightweight. Linux uses distro clipboard tools with 300 ms polling;
+  do not apply macOS/Windows idle measurements to it. HTTP is `curl`; JSON output is
   hand-rolled in `common::json_escape`. If you need serde, justify it.
 - **Pure functions for anything with logic.** Parsing, ordering, config
   rewriting, and rendering are all separated from I/O so they can be tested

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ version = "2.4.2"
 dependencies = [
  "block2",
  "image",
+ "libc",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,17 @@
 name = "clipaste"
 version = "2.4.2"
 edition = "2021"
-description = "Fix macOS/Windows screenshot paste in terminal AI tools"
+description = "Bridge macOS, Windows and Linux screenshots to terminal AI tools"
 license = "MIT"
 repository = "https://github.com/hqhq1025/clipaste"
 
 [dependencies]
 image = { version = "0.25", default-features = false, features = ["tiff", "png", "bmp"] }
 sha2 = "0.10.9"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# Bound clipboard subprocesses, including wl-paste's child process, as one group.
+libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Fix screenshot paste in terminal AI tools — locally, over SSH, and in WSL2.
 
 **[hqhq1025.github.io/clipaste](https://hqhq1025.github.io/clipaste/)** · [AGENTS.md](AGENTS.md) · [Issues](https://github.com/hqhq1025/clipaste/issues)
 
-**clipaste** is a lightweight clipboard daemon for developers who use terminal-based AI coding tools like Claude Code, Codex CLI, and Cursor. Install with one command via Homebrew (macOS) or PowerShell (Windows), and screenshot paste just works — in Ghostty, Alacritty, iTerm2, Kitty, WezTerm, and more. It also bridges your clipboard to remote servers over SSH and to WSL2 environments. Written in Rust, clipaste uses only 9 MB of RAM with 0% CPU overhead.
+**clipaste** is a lightweight Rust clipboard daemon for developers who use terminal-based AI coding tools like Claude Code, Codex CLI, and Cursor. It fixes local screenshot paste on macOS and Windows, bridges their clipboards to remote servers over SSH, and connects Windows to WSL2. Graphical Linux hosts can also serve clipboard PNG images over SSH using the read-only backend described below.
 
 **Problem:** You take a screenshot, switch to Claude Code / Codex / Cursor in your terminal, press **Ctrl+V** — nothing happens. Or you're SSH'd into a remote server and can't paste screenshots at all.
 
 **Why:** macOS screenshots only put raw image data (TIFF/PNG) on the clipboard. Terminals like Ghostty and Alacritty can only Cmd+V paste text or file URLs — they can't paste raw image data. Over SSH, the remote server has no access to your local clipboard whatsoever.
 
-**Solution:** clipaste is a tiny background daemon (9 MB RAM, 0% CPU) that:
+**Solution:** clipaste is a background daemon that:
 
-1. **Local paste:** Saves screenshots as temp PNG files and registers the file path on the clipboard, so **Cmd+V** works in terminals. Also adds the legacy PNGf type so **Ctrl+V** image paste works too.
+1. **Local paste on macOS / Windows:** Saves screenshots as PNG files and adds a path alongside the image. On macOS, this enables **Cmd+V** in terminals and adds the legacy PNGf type for **Ctrl+V** image paste. Linux reads the clipboard without adding a path or changing its formats.
 
 2. **SSH remote paste:** Runs an HTTP server on `localhost:18340`. Use `clipaste ssh-setup` to configure a remote server — it installs an xclip shim and SSH tunnel so **Ctrl+V** in remote Claude Code fetches the image from your local machine.
 
@@ -20,19 +20,22 @@ Fix screenshot paste in terminal AI tools — locally, over SSH, and in WSL2.
 
 ### Supported platforms
 
-The clipboard-host daemon runs on macOS and Windows only. Native Linux clipboard
-hosting is not implemented, for either Wayland or X11.
+The clipboard-host daemon runs on macOS, Windows, and graphical Linux sessions
+with a usable clipboard backend. Linux hosting is read-only and accepts
+`image/png`; desktop/compositor compatibility must be verified in the user's session.
 
 | OS / context | Local clipboard-host daemon | Consumer of another host's clipboard |
 |---|---|---|
 | macOS | Supported | SSH remote via `clipaste-paste` |
 | Windows | Supported | Via WSL2, as described below |
-| Native Linux | Not implemented | Supported over SSH via shims / `clipaste-paste` |
+| Native Linux desktop | PNG hosting via Wayland data-control or X11/XWayland; see requirements below | Supported over SSH via shims / `clipaste-paste` |
+| Headless Linux | No desktop clipboard; host startup fails with guidance | Supported with configured helpers / SSH |
 | WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
 
-Linux shims fetch images from an existing macOS or Windows daemon; they do not
-watch the Linux desktop clipboard. Run `ssh-setup` on that local Mac or Windows
-clipboard host with its daemon running. On macOS remotes, use `clipaste-paste`.
+Linux consumer shims fetch images from an existing macOS, Windows, or graphical
+Linux host daemon. The Linux host uses real system clipboard tools, never these
+HTTP shims. Run `ssh-setup` on the clipboard host with its daemon running.
+On macOS remotes, use `clipaste-paste`.
 
 ### Clipboard history and cache
 
@@ -43,6 +46,11 @@ Cached images no longer expire automatically after one hour, so saved history
 paths remain usable. Storage grows with unique images; deleting cached files
 invalidates history entries that reference those paths.
 See [clipboard history compatibility](docs/clipboard-history.md) for details.
+
+Linux also uses the private stable PNG cache (`~/.cache/clipaste`, directory
+mode `0700`, files `0600`). Clearing the clipboard, copying non-image content,
+or encountering a recognized private marker clears the staged image served over
+HTTP. Historical cached paths are retained; clearing the clipboard does not erase them.
 
 ### macOS (Homebrew)
 
@@ -57,24 +65,81 @@ brew services start clipaste
 irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex
 ```
 
-### Build from source
+### Linux desktop (from source)
 
-`cargo build` and `cargo install` remain allowed on Linux for development,
-`doctor`, and consumer setup, including WSL2 setup. A successful build or install
-does not make Linux a supported local clipboard host. There is no blanket
-`compile_error!` gate because these CLI tools are needed on consumer machines.
+Install Rust/Cargo first. On Ubuntu, install the distro clipboard tools and
+`curl`, then build and install from the source checkout. These Linux instructions
+describe source builds, not a tagged Linux binary release:
 
 ```bash
+sudo apt install wl-clipboard xclip curl
 git clone https://github.com/hqhq1025/clipaste.git
 cd clipaste
-cargo build --release
+cargo install --path .
+clipaste
 ```
+
+Run `clipaste` as your desktop user in a terminal opened from the graphical
+session, and leave it running. Ensure Cargo's binary directory (`~/.cargo/bin`
+by default) is on `PATH`. No Linux service or automatic startup is installed.
+In a separate terminal in the same desktop session, verify and configure SSH:
+
+```bash
+clipaste doctor --json
+clipaste ssh-setup user@your-server
+```
+
+Take a screenshot copied as image data, re-run `doctor`, then open a new SSH
+session and test `clipaste-paste` or the supported remote tool's paste gesture.
+An empty clipboard warning before taking the screenshot is normal.
+
+| `CLIPASTE_BACKEND` | Selection and requirements |
+|---|---|
+| `auto` (default) | Prefer native Wayland when data-control is available; otherwise use system `xclip` through `DISPLAY`, warning when falling back from Wayland to XWayland |
+| `wayland` | Require real system `wl-paste` with usable data-control access as described below; fail instead of falling back |
+| `x11` | Require real system `xclip` and a usable `DISPLAY`, using X11 or the compositor's XWayland clipboard bridge |
+
+For example, `CLIPASTE_BACKEND=x11 clipaste` selects X11 explicitly. Use the
+same override for diagnostics: `CLIPASTE_BACKEND=x11 clipaste doctor --json`.
+Native Wayland requires `wl-clipboard >=2.2` for empty-selection watch events.
+All Wayland clipboard accesses use `wl-paste --watch` in bounded one-shot mode,
+which refuses popup fallback and verifies actual compiled-in data-control
+support. Ext-only compositors need `wl-clipboard >=2.3` built with
+`ext-data-control` support; `wlr-data-control` works with compatible 2.2+ builds.
+With 2.1.x or unavailable data-control, `auto` warns and falls back to XWayland
+through system `xclip` and an accessible `DISPLAY`; without that, it fails with
+guidance to upgrade or use an X11 session. No forced-focus polling is used.
+
+GNOME Wayland may need the XWayland clipboard bridge. Its behavior depends on
+the compositor and source application: reporters must test a screenshot copied
+from a native Wayland app and verify the image received on the remote. An
+X11-only copy test does not establish native Wayland compatibility. Universal
+desktop/compositor compatibility has not been tested.
+
+Linux polls every 300 ms and reads only `image/png`. The pipeline is clipboard
+PNG -> private stable PNG cache -> existing loopback HTTP server -> SSH shims /
+`clipaste-paste`. It does not write file URLs or text back to the Linux clipboard,
+so local terminal text-path paste is not promised. Copying an image file in a
+file manager that offers only a URI is not supported yet; copy the image pixels
+or a screenshot instead. Existing macOS and Windows paste workflows remain unchanged.
+
+### Build from source
+
+For development on any supported platform, use `cargo build --release` from the
+checkout. Linux builds also retain `doctor` and consumer setup commands,
+including `wsl-setup`; WSL2 remains a consumer of the Windows daemon.
+
+For opt-in verification with real clipboard tools, run `bash tests/linux/run.sh`
+from the repository root on Linux. It starts isolated Xvfb and headless Sway
+sessions and uses temporary test state, not your real desktop clipboard.
+See [test prerequisites and container recipe](AGENTS.md#build-and-test).
+This does not replace the native-app screenshot check for your own compositor.
 
 ## SSH Remote Paste
 
 clipaste can bridge your local clipboard to remote servers over SSH. Run this
-one-time setup on your local Mac or Windows clipboard host, with its daemon
-running, not on the Linux consumer:
+one-time setup on your local macOS, Windows, or graphical Linux clipboard host,
+with its daemon running, not on the remote consumer:
 
 ```bash
 clipaste ssh-setup user@your-server
@@ -92,7 +157,7 @@ After setup, open a **new** SSH session:
 
 ```bash
 ssh user@your-server
-claude   # Ctrl+V pastes screenshots from your local Mac (Linux remote)
+claude   # Ctrl+V pastes screenshots from your clipboard host (Linux remote)
 codex    # run `clipaste-paste`, then paste the printed path (see below)
 ```
 
@@ -107,15 +172,16 @@ use the `clipaste-paste` helper that `ssh-setup` installs:
 clipaste-paste            # → /tmp/clipaste-<ts>.png  (a real file on the remote)
 ```
 
-Take a screenshot (or copy an image file) on your Mac, run `clipaste-paste` on the
-remote, and hand the printed path to Codex / Claude Code — both accept an image
-file path. This works the same on Linux and macOS remotes.
+Copy a screenshot on the clipboard host, run `clipaste-paste` on the remote,
+and hand the printed path to Codex / Claude Code. On macOS, copying an image
+file also works; Linux currently requires clipboard `image/png`, not a file URI.
+The helper works on both Linux and macOS remotes.
 
 ### How SSH paste works (Claude Code, Linux remote)
 
 ```
-Local Mac                          Remote Server (via SSH)
-─────────                          ──────────────────────
+Clipboard host                     Remote Server (via SSH)
+──────────────                     ──────────────────────
 Screenshot                         Claude Code runs "xclip"
     │                                      │
     ▼                                      ▼
@@ -204,9 +270,12 @@ remotes use the `clipaste-paste` helper instead (Codex bypasses the xclip shim).
 
 ## Compatibility
 
-Local support below means a macOS or Windows clipboard host, not a native Linux
-host. SSH Ctrl+V support means a Linux consumer using the shims; macOS remotes
-use `clipaste-paste`. WSL2 always requires the Windows daemon.
+Local paste shortcuts below apply to macOS and Windows. Linux hosting supplies
+PNG images to the SSH bridge without adding local text-path paste. SSH Ctrl+V
+means a Linux consumer using the shims, backed by any supported clipboard host;
+macOS remotes use `clipaste-paste`. WSL2 always requires the Windows daemon.
+The Linux backend does not change the existing macOS/Windows workflows, and
+these tables do not certify every Linux desktop, compositor, or application.
 
 | Terminal | macOS Cmd+V | macOS Ctrl+V | Windows Ctrl+V | SSH Ctrl+V | WSL2 Ctrl+V |
 |----------|:-----------:|:------------:|:--------------:|:----------:|:-----------:|
@@ -218,7 +287,7 @@ use `clipaste-paste`. WSL2 always requires the Windows daemon.
 | Kitty    | ✅          | ✅           | ✅             | ✅         | ✅          |
 | Windows Terminal | —   | —            | ✅             | —          | ✅          |
 
-| AI Tool | Local | SSH Remote | WSL2 |
+| AI Tool | Local macOS / Windows | SSH Remote | WSL2 |
 |---------|:-----:|:----------:|:----:|
 | Claude Code | ✅ | ✅ Ctrl+V | ✅ Ctrl+V |
 | Codex CLI   | ✅ | ⚠️ via `clipaste-paste` | ⚠️ via `clipaste-paste` |
@@ -259,20 +328,24 @@ Exit code is `0` when usable (including warnings), `1` when broken, `2` on bad
 arguments. Every setup command is non-interactive and idempotent, so an agent
 can run them unattended.
 
-`unsupported-host` extends the role contract for an unsupported local machine
-with no WSL context, SSH session, or configured consumer helper. It reports
-`fail` with exit code `1`; its `platform` check explains the limit with `fix: null`.
-WSL detection takes precedence over SSH; actual SSH
-sessions remain `ssh-remote`, including SSH into macOS. A configured Linux
-consumer also remains `ssh-remote` when SSH environment variables are absent,
-so helper and bridge diagnostics still apply.
+WSL detection takes precedence over SSH and remains `wsl2`, even with graphical
+environment variables. Actual SSH sessions remain `ssh-remote`, including SSH
+into macOS or a Linux desktop. A graphical local Linux session is a
+`clipboard-host`; a headless Linux machine with a configured consumer helper
+remains `ssh-remote` even without SSH variables. Headless Linux with no consumer
+indicators gets `clipboard-host` diagnostics with a failing `backend` check.
+`unsupported-host` remains in the contract for platforms without a backend;
+it is not a blanket Linux result.
 
-An `unsupported-host` failure is a platform capability limit, not a missing
-systemd service, PATH entry, or `curl` dependency. Those changes cannot enable
-a Linux clipboard host. To consume another machine's clipboard, start the
-daemon on a Mac or Windows host, run `ssh-setup` there, and open a new SSH
-session to Linux; for WSL2, keep the Windows daemon running and use `wsl-setup`.
-There is no command that enables a native Linux backend.
+Run Linux host diagnostics as the same desktop user, from the same graphical
+session as the daemon, with the same `CLIPASTE_BACKEND` override. Wayland needs
+the session's `WAYLAND_DISPLAY` and `XDG_RUNTIME_DIR`; X11/XWayland needs `DISPLAY`
+and authorization to that display. An SSH shell, `sudo`, a stale tmux session,
+or a service missing that environment may produce different diagnostics.
+Setting a display variable alone does not create or authorize a desktop session.
+With no display, host startup fails with guidance to run from the desktop or
+configure a consumer. Missing tools and missing data-control need their stated
+remedies; installing `curl` or a systemd service does not grant clipboard access.
 
 ## Managing
 
@@ -291,11 +364,20 @@ taskkill /IM clipaste.exe /F                      # stop
 Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "clipaste"  # disable auto-start
 ```
 
+### Linux
+
+Keep `clipaste` running in its graphical-session terminal; stop it with Ctrl+C.
+Restart it there after changing `CLIPASTE_BACKEND`. No Linux service is installed
+automatically. Run `clipaste doctor --json` in a separate desktop terminal.
+
 ## FAQ
 
 ### How do I paste screenshots in Claude Code?
 
 Install clipaste with `brew install hqhq1025/clipaste/clipaste && brew services start clipaste` on macOS, or the PowerShell one-liner on Windows. Once running, take a screenshot and press **Ctrl+V** in Claude Code — the image pastes automatically. No configuration needed. clipaste runs as a background daemon and handles the clipboard conversion for you.
+
+For a Linux clipboard host, follow [Linux desktop setup](#linux-desktop-from-source)
+and the SSH workflow. The read-only backend does not add local text-path paste.
 
 ### Why can't I paste images in my terminal on macOS?
 
@@ -303,9 +385,9 @@ macOS screenshots place raw TIFF/PNG image data on the clipboard, but terminals 
 
 ### How do I paste clipboard images over SSH?
 
-Run `clipaste ssh-setup user@your-server` once on your local Mac or Windows
-clipboard host with its daemon running (add `-p PORT` for a non-default SSH
-port). It detects the remote OS, installs a lightweight
+Run `clipaste ssh-setup user@your-server` once on your local macOS, Windows, or
+graphical Linux clipboard host with its daemon running (add `-p PORT` for a
+non-default SSH port). It detects the remote OS, installs a lightweight
 xclip shim (Linux) plus a universal `clipaste-paste` helper, and configures an SSH
 tunnel. After setup, open a new SSH session:
 
@@ -327,11 +409,18 @@ automatically — see [WSL2 networking modes](#wsl2-networking-modes).
 
 ### How much memory and CPU does clipaste use?
 
-clipaste uses approximately 9 MB of RAM and 0% CPU when idle. It is written in Rust and runs as a tiny background daemon. On macOS it is managed via `brew services`; on Windows it auto-starts via a Registry Run key. It has no runtime dependencies beyond the OS clipboard APIs.
+The existing macOS/Windows footprint is approximately 9 MB of RAM with no
+measurable idle CPU. That is not a Linux measurement: Linux polls every 300 ms
+and invokes system clipboard tools. macOS uses `brew services`; Windows uses a
+Registry Run key. Linux runs from the graphical session and requires the distro
+tools listed above.
 
 ### Which terminals and AI tools does clipaste support?
 
 clipaste works with Ghostty, Alacritty, iTerm2, Terminal.app, WezTerm, Kitty, and Windows Terminal. It supports Claude Code, Codex CLI, and Cursor CLI. **Cmd+V** (macOS local) and **Ctrl+V** (local, plus SSH/WSL2 for shim-based tools like Claude Code) are supported; Codex CLI and macOS remotes use the `clipaste-paste` helper. See the compatibility tables above for the full matrix.
+
+Local shortcuts here refer to macOS/Windows. Linux host compatibility depends
+on clipboard access and the source app; verify it with a real screenshot.
 
 ## How is this different from...
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13,8 +13,10 @@ Author: Haoqing Wang (https://github.com/hqhq1025)
 
 clipaste is a clipboard daemon that makes screenshot paste work in terminal-based AI
 coding tools — Claude Code, Codex CLI and Cursor CLI — on macOS and Windows, and bridges
-the clipboard to SSH remotes and WSL2 environments. It uses about 9 MB of resident memory
-and has no measurable idle CPU cost.
+the clipboard to SSH remotes and WSL2 environments. Graphical Linux hosts also serve
+clipboard PNG images over SSH through a read-only backend. The existing macOS/Windows
+footprint is about 9 MB with no measurable idle CPU; this is not a Linux measurement,
+since Linux polls and invokes system clipboard tools.
 
 ---
 
@@ -38,11 +40,18 @@ Three separate failures are usually reported as one:
 
 ## How clipaste solves it
 
-**Locally.** A background daemon watches the clipboard. When a screenshot appears, it
-writes the bytes to a temporary PNG file and puts that file's path on the clipboard
-*alongside* the original image data. A file path is something the terminal can pass
-through, so Cmd+V works; the retained image data plus a legacy PNGf pasteboard type keeps
-Ctrl+V image paste working for tools that read the clipboard directly.
+Locally on macOS/Windows, a background daemon watches the clipboard. When a
+screenshot appears, it writes the bytes to a PNG file and adds its path alongside
+the original image data. On macOS, a file path is something the terminal can pass
+through, so Cmd+V works; the retained image data plus a legacy PNGf pasteboard type
+keeps Ctrl+V image paste working for tools that read the clipboard directly.
+
+On Linux, the daemon reads clipboard `image/png` into a private stable PNG cache
+without taking clipboard ownership or adding file URLs/text. The pipeline is
+clipboard PNG -> cache -> existing loopback HTTP -> SSH shims / `clipaste-paste`.
+It does not promise local terminal text-path paste. Copying an image file that
+offers only a URI is not supported yet; copy image pixels or a screenshot.
+Existing macOS/Windows clipboard behavior and paste workflows are unchanged.
 
 **Over SSH.** The daemon also runs an HTTP server bound to `127.0.0.1:18340` serving three
 endpoints: `/health`, `/clipboard/type` and `/clipboard/image`. `clipaste ssh-setup`
@@ -59,7 +68,7 @@ wsl-setup` installs the same shims inside the distro, pointed at clipaste.exe on
 ## Commands
 
 ```
-clipaste                       Run the daemon (macOS / Windows only)
+clipaste                       Run the daemon (macOS / Windows / graphical Linux)
 clipaste doctor [--json]       Diagnose this machine and print the fix command
 clipaste ssh-setup user@host   Configure an SSH remote (add -p PORT for a custom SSH port)
 clipaste wsl-setup             Configure WSL2 (add --host IP to skip host auto-detection)
@@ -76,18 +85,21 @@ fetches the current clipboard image into a real file on that host and prints the
 
 ### Supported hosts and consumers
 
-The clipboard-host daemon runs on macOS and Windows only. Native Linux clipboard
-hosting is not implemented, for either Wayland or X11.
+The clipboard-host daemon runs on macOS, Windows, and graphical Linux with usable
+clipboard access. Linux support depends on the compositor and source application;
+universal desktop compatibility has not been tested.
 
 | OS / context | Local clipboard-host daemon | Consumer of another host's clipboard |
 |---|---|---|
 | macOS | Supported | SSH remote via `clipaste-paste` |
 | Windows | Supported | Via WSL2 |
-| Native Linux | Not implemented | Supported over SSH via shims / `clipaste-paste` |
+| Native Linux desktop | Read-only PNG via Wayland data-control or X11/XWayland | Supported over SSH via shims / `clipaste-paste` |
+| Headless Linux | No display; host startup fails with guidance | Supported with configured helpers / SSH |
 | WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
 
-Linux shims fetch images from a macOS or Windows daemon; they do not own or
-watch the Linux desktop clipboard. On macOS remotes, use `clipaste-paste`.
+Linux consumer shims fetch images from a macOS, Windows, or graphical Linux
+host daemon. The Linux host resolves real system clipboard tools, not the
+generated HTTP shims. On macOS remotes, use `clipaste-paste`.
 
 macOS (Homebrew):
 
@@ -105,24 +117,87 @@ irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex
 The Windows installer downloads the latest release into `%LOCALAPPDATA%\clipaste`, adds it
 to the user PATH, registers an `HKCU\...\Run` auto-start entry, and launches the daemon.
 
-From source:
+Linux desktop from source (Rust/Cargo required; Ubuntu package example):
+
+These Linux instructions describe the source checkout, not a tagged Linux
+binary release.
 
 ```bash
+sudo apt install wl-clipboard xclip curl
 git clone https://github.com/hqhq1025/clipaste.git
-cd clipaste && cargo build --release
+cd clipaste
+cargo install --path .
+clipaste
 ```
 
-`cargo build` and `cargo install` on Linux remain allowed for development,
-`doctor`, and consumer setup, including WSL2 setup. Build success does not imply
-local clipboard-host support. No blanket `compile_error!` gate is used because
-the CLI tools are needed on Linux consumers.
+Ensure Cargo's binary directory (`~/.cargo/bin` by default) is on `PATH`. Run
+`clipaste` as the desktop user in a graphical-session terminal and leave it
+running. No Linux service or automatic startup is installed. Stop with Ctrl+C;
+restart from the same graphical session. In a separate desktop terminal:
+
+```bash
+clipaste doctor --json
+clipaste ssh-setup user@your-server
+```
+
+Copy a screenshot as image data and re-run `doctor`; an empty clipboard warning
+before copying is normal. Open a new SSH session and verify the fetched image
+with `clipaste-paste` or a supported shim-based paste gesture.
+
+For development, run `cargo build --release` in the checkout. Linux builds
+retain diagnostics and consumer setup commands, including `wsl-setup`; WSL2
+remains a Windows consumer.
+
+### Linux backend selection
+
+| `CLIPASTE_BACKEND` | Behavior |
+|---|---|
+| `auto` (default) | Prefer native Wayland data-control; otherwise use system `xclip` through `DISPLAY`, explicitly warning when falling back from Wayland to XWayland |
+| `wayland` | Require system `wl-paste` with usable data-control access as described below; fail instead of falling back |
+| `x11` | Require system `xclip` and an accessible `DISPLAY`, using X11 or the compositor's XWayland clipboard bridge |
+
+Native Wayland requires `wl-clipboard >=2.2` for empty-selection watch events.
+All Wayland clipboard accesses use `wl-paste --watch` in bounded one-shot mode,
+which refuses popup fallback and verifies actual compiled-in data-control
+support. Ext-only compositors need `wl-clipboard >=2.3` built with
+`ext-data-control` support; `wlr-data-control` works with compatible 2.2+ builds.
+With 2.1.x or unavailable data-control, `auto` warns and falls back to XWayland
+through system `xclip` and an accessible `DISPLAY`; without that, it fails with
+guidance to upgrade or use an X11 session. No forced-focus polling is used.
+No display fails with guidance to start from a graphical desktop or configure
+a consumer instead.
+
+For an explicit backend, start `CLIPASTE_BACKEND=x11 clipaste`, then run
+`CLIPASTE_BACKEND=x11 clipaste doctor --json` in a separate terminal. Keep the
+override and desktop environment consistent across both processes.
+
+GNOME Wayland may need the XWayland clipboard bridge. Reporters must test a
+screenshot copied from a native Wayland app, inspect `doctor`, and verify the
+actual image fetched on the remote. An X11-only clipboard test does not establish
+native Wayland compatibility, and backend detection alone is not an end-to-end
+test. Record the compositor/session, source app, backend, and diagnostic result
+when reporting compatibility.
+
+Linux polls every 300 ms and only reads `image/png`. Clipboard clears, non-image
+content, and recognized private markers clear the staged image served over HTTP.
+Historical cached paths are retained; clearing the clipboard does not erase the cache.
+
+### Opt-in Linux desktop verification
+
+Run `bash tests/linux/run.sh` from the repository root on Linux. It runs unit
+tests, strict Clippy, and real clipboard/HTTP smoke tests in isolated Xvfb and
+headless Sway sessions. Temporary HOME/cache/runtime directories keep test state
+separate; the tests do not use the real user's clipboard. See `AGENTS.md` for
+distro prerequisites and the existing `tests/linux/Dockerfile` container recipe.
+Direct runs require loopback port `18340` to be free. Passing isolated tests does
+not establish GNOME/ext-only compatibility or replace native-app screenshot tests.
 
 ---
 
 ## SSH remote setup, in detail
 
-Run on the local Mac or Windows clipboard host with its daemon running, not on
-the Linux consumer or other remote:
+Run on the local macOS, Windows, or graphical Linux clipboard host with its daemon
+running, not on the remote consumer:
 
 ```bash
 clipaste ssh-setup user@your-server
@@ -189,6 +264,9 @@ unavailable, forward the port on the Windows side with `netsh interface portprox
 
 On macOS locally, Cmd+V also works — that is the case the file-path trick was built for.
 
+The local column does not apply to Linux hosts. Linux adds no clipboard text or
+file URLs; its supported host workflow supplies PNG images to remote consumers.
+
 **Codex CLI is the standing exception.** It reads the clipboard in-process through the
 `arboard` crate, which talks to X11 or Wayland directly and never executes the `xclip`
 binary. There is no environment variable or external-command hook to redirect it, so a
@@ -226,12 +304,12 @@ Contract:
 - `role` is `clipboard-host`, `ssh-remote`, `wsl2`, or `unsupported-host`, and
   decides which checks run. `unsupported-host` is an extension of the role
   contract; callers must accept the additional value.
-- Detection order is WSL context, then SSH session, then a supported local
-  macOS / Windows host, then a configured consumer helper, otherwise
-  `unsupported-host`. WSL takes precedence even with SSH variables present.
-  Actual SSH sessions remain `ssh-remote`, including SSH into macOS. A configured
-  Linux consumer also stays `ssh-remote` without SSH environment variables, so
-  helper and bridge checks still run.
+- Detection order is WSL context, then SSH session, then a local macOS/Windows
+  host or graphical Linux session. WSL stays a Windows consumer even with SSH
+  or display variables. Actual SSH sessions remain `ssh-remote`, including SSH
+  into macOS or graphical Linux. Graphical local Linux is `clipboard-host`;
+  headless Linux with a configured consumer helper remains `ssh-remote` even
+  without SSH variables, so helper and bridge checks still run.
 - `status` is the worst of all checks: `ok`, `warn` or `fail`.
 - `checks[].fix` is a remediation command or guidance, or `null` when no single
   command applies.
@@ -239,18 +317,23 @@ Contract:
 - A `warn` is not a failure. "No screenshot staged yet" is the normal state of a fresh
   install; treating it as a fault causes an agent to loop.
 
-`unsupported-host` reports `fail` with exit code `1` for a local machine whose
-clipboard-host backend is unsupported and which has no WSL context, SSH session,
-or configured consumer helper. This is a capability failure, not a missing
-systemd service, PATH entry, or `curl` dependency. Installing dependencies or
-adding a service cannot enable native Linux clipboard hosting.
-The `platform` check puts the explanation and supported setup paths in `detail`,
-with `fix: null` because no single command can add the missing backend.
+`unsupported-host` remains in the contract for platforms without a backend; it
+is not a blanket Linux classification. Linux without a display or consumer
+configuration gets `clipboard-host` diagnostics with a failing `backend` check
+and actionable graphical-session guidance. Missing distro tools, inaccessible
+displays, and absent Wayland data-control need distinct remedies; adding a
+service or installing `curl` does not supply desktop access.
 
-To consume a supported host's clipboard on Linux, start the daemon on that
-local Mac or Windows host, run `ssh-setup` there, and open a new SSH session.
-For WSL2, keep the Windows daemon running and run `wsl-setup` in the distro.
-No command enables a native Linux backend.
+Run Linux host diagnostics as the same desktop user and in the same session as
+the daemon. Wayland requires the session's `WAYLAND_DISPLAY` and `XDG_RUNTIME_DIR`;
+X11/XWayland requires `DISPLAY` and display authorization. Use the same
+`CLIPASTE_BACKEND` override. SSH shells, `sudo`, stale tmux sessions, and services
+can lack the required environment. Setting a display variable alone does not
+establish or authorize a connection.
+
+To consume another host's clipboard on Linux, run `ssh-setup` on that macOS,
+Windows, or graphical Linux host with its daemon running, then open a new SSH
+session. WSL2 still requires the Windows daemon and `wsl-setup` in the distro.
 
 Checks distinguish failure modes that look identical from outside: helper missing, helper
 installed but not on PATH, shim shadowed by the real `xclip`, tunnel down, and a stale
@@ -270,9 +353,13 @@ Kitty on macOS; Windows Terminal, PowerShell and cmd.exe on Windows. WezTerm and
 also cover Windows Ctrl+V.
 
 Consumers: Linux servers reachable over SSH with `curl`, backed by a macOS or
-Windows clipboard host. WSL2 distros including Ubuntu, Debian, Fedora, Arch and
+Windows clipboard host or a graphical Linux host with usable clipboard access.
+WSL2 distros including Ubuntu, Debian, Fedora, Arch and
 Kali require the Windows daemon. macOS remotes are supported through
-`clipaste-paste`. Native Linux clipboard hosting is not implemented.
+`clipaste-paste`. Linux hosting is read-only PNG capture, not local terminal
+text-path paste. GNOME Wayland may require a working XWayland clipboard bridge;
+test native-app screenshots rather than assuming universal compatibility.
+Linux verification is not a substitute for macOS/Windows regression checks.
 
 ---
 
@@ -287,6 +374,9 @@ Kali require the Windows daemon. macOS remotes are supported through
   SHA-256 paths. Published files no longer expire automatically, so clipboard
   history paths remain valid. Disk usage grows with unique images; explicitly
   deleting cached files invalidates any saved paths that reference them.
+- Linux cache directories use `0700` and PNG files use `0600`. Clipboard clears,
+  non-image content, and recognized private markers clear the currently staged
+  image without deleting historical cache files.
 - No telemetry, no network calls other than serving the local endpoints.
 
 ---
@@ -303,9 +393,14 @@ Kali require the Windows daemon. macOS remotes are supported through
   `AddClipboardFormatListener` and handles `WM_CLIPBOARDUPDATE`, de-duplicated with
   `GetClipboardSequenceNumber`. `CF_DIB` is converted to PNG and the path written back as
   `CF_UNICODETEXT`. There is no polling loop.
+- Linux: polls every 300 ms using bounded one-shot `wl-paste --watch` calls
+  for Wayland data-control, or system `xclip` for X11/XWayland. Reads `image/png`
+  into the private stable cache without rewriting clipboard formats. Auto
+  fallback from native Wayland is explicitly warned; no forced-focus polling.
 - **HTTP**: a hand-rolled server on the standard library's `TcpListener`. No web framework.
-- **Dependencies**: only the `image` crate for format conversion, plus `objc2` on macOS and
-  `windows-sys` on Windows. HTTP requests made by the CLI shell out to `curl`.
+- Runtime tools: Linux uses `wl-clipboard` and/or `xclip`
+  according to the selected backend. HTTP requests made by the CLI use `curl`.
+  macOS/Windows retain their native clipboard APIs.
 
 ---
 
@@ -318,9 +413,9 @@ arrives empty. clipaste writes the screenshot to a temp PNG and puts that path o
 clipboard alongside the image data.
 
 **Can I paste screenshots into Claude Code running on a remote server over SSH?**
-Yes. Run `clipaste ssh-setup user@host` from the local Mac or Windows clipboard
-host with its daemon running, then open a new SSH session. On Linux remotes,
-press Ctrl+V in Claude Code; on macOS remotes, use `clipaste-paste`.
+Yes. Run `clipaste ssh-setup user@host` from the local macOS, Windows, or graphical
+Linux clipboard host with its daemon running, then open a new SSH session.
+On Linux remotes, press Ctrl+V in Claude Code; on macOS remotes, use `clipaste-paste`.
 
 **Why can't Codex CLI paste images over SSH the way Claude Code can?**
 Codex reads the clipboard in-process via `arboard` and never runs `xclip`, so it bypasses
@@ -331,7 +426,9 @@ Yes, with the Windows daemon already running. Run `clipaste wsl-setup` inside
 the distro; see the networking requirements above.
 
 **How much memory and CPU does clipaste use?**
-About 9 MB resident and no measurable idle CPU.
+The existing macOS/Windows footprint is about 9 MB resident with no measurable
+idle CPU. Linux polls every 300 ms and invokes system tools; those measurements
+do not establish its resource use.
 
 **Does clipaste send my screenshots anywhere?**
 No. Loopback only, with no telemetry.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,8 +1,9 @@
 # clipaste
 
-> A 9 MB Rust clipboard daemon that makes screenshot paste work in terminal-based AI
+> A lightweight Rust clipboard daemon that makes screenshot paste work in terminal-based AI
 > coding tools (Claude Code, Codex CLI, Cursor CLI) on macOS and Windows, and bridges
-> the clipboard across SSH and WSL2 boundaries. MIT licensed.
+> the clipboard across SSH and WSL2 boundaries. Graphical Linux hosts provide
+> read-only PNG capture for the SSH bridge. MIT licensed.
 
 clipaste exists because of a specific, verifiable gap: a macOS screenshot places only
 raw image bytes (TIFF/PNG) on the pasteboard, and terminals such as Ghostty and
@@ -11,33 +12,86 @@ bytes to the program they host. The keystroke arrives carrying nothing. Over SSH
 remote has no access to the local clipboard at all, so tools fall back to inserting the
 local file path as literal text — a path that does not exist on the remote.
 
-clipaste watches the clipboard, writes each screenshot to a temporary PNG, and puts that
-file's path on the clipboard alongside the image data. It also serves the same PNG on
+On macOS/Windows, clipaste watches the clipboard, saves each screenshot as a PNG,
+and adds a path alongside the image data. Linux reads PNG without changing the
+clipboard. Each host serves the staged PNG on
 `127.0.0.1:18340`, so a remote reachable through an SSH RemoteForward tunnel can fetch
 the picture rather than a meaningless path.
 
 ## Install
 
-The clipboard-host daemon supports macOS and Windows only. Native Linux clipboard
-hosting is not implemented on either Wayland or X11.
+The daemon supports macOS, Windows, and graphical Linux with usable clipboard
+access. Linux hosting reads `image/png` only; it does not add local text-path paste.
 
 | OS / context | Local clipboard-host daemon | Consumer of another host's clipboard |
 |---|---|---|
 | macOS | Supported | SSH remote via `clipaste-paste` |
 | Windows | Supported | Via WSL2 |
-| Native Linux | Not implemented | Supported over SSH via shims / `clipaste-paste` |
+| Native Linux desktop | Read-only PNG via Wayland data-control or X11/XWayland | Supported over SSH via shims / `clipaste-paste` |
+| Headless Linux | No display; host startup fails with guidance | Supported with configured helpers / SSH |
 | WSL2 | No; the Windows daemon is required | Supported via `wsl-setup` |
 
 - macOS: `brew install hqhq1025/clipaste/clipaste && brew services start clipaste`
 - Windows: `irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex`
 - Verify: `clipaste doctor` (add `--json` for machine-readable output)
-- SSH remote: `clipaste ssh-setup user@host`, run on the local Mac or Windows clipboard host with its daemon running
+- SSH remote: `clipaste ssh-setup user@host`, run on the local macOS, Windows, or graphical Linux clipboard host with its daemon running
 - WSL2: `clipaste wsl-setup` — run this inside the distro, with clipaste.exe running on Windows
 
-Linux `cargo build` and `cargo install` remain allowed for development, `doctor`,
-and consumer setup. They do not enable a local Linux daemon. A blanket
-`compile_error!` gate would also block these needed CLI tools. Linux shims consume
-images from the supported host; they do not watch the Linux clipboard.
+Linux desktop installation requires Rust/Cargo and distro tools. On Ubuntu:
+
+```bash
+sudo apt install wl-clipboard xclip curl
+git clone https://github.com/hqhq1025/clipaste.git
+cd clipaste
+cargo install --path .
+clipaste
+```
+
+Put Cargo's binary directory (normally `~/.cargo/bin`) on `PATH`. Run `clipaste`
+as your desktop user from a graphical terminal and leave it running. No Linux
+service or auto-start is installed. In a separate terminal in the same session:
+
+```bash
+clipaste doctor --json
+clipaste ssh-setup user@host
+```
+
+Linux builds retain diagnostics and consumer setup, including `wsl-setup`.
+Consumer shims fetch from HTTP; the Linux host resolves real system clipboard
+tools, not the generated shims.
+
+## Linux backend contract
+
+- `CLIPASTE_BACKEND=auto` (default): prefer system `wl-paste` with usable
+  data-control access; otherwise warn and use system `xclip` through an
+  accessible `DISPLAY`, or fail with actionable guidance if unavailable.
+- Native Wayland requires `wl-clipboard >=2.2` for empty-selection watch events.
+  All Wayland clipboard accesses use `wl-paste --watch` in bounded one-shot mode,
+  which refuses popup fallback and verifies actual compiled-in data-control
+  support. Ext-only compositors need `wl-clipboard >=2.3` built with
+  `ext-data-control` support; `wlr-data-control` works with compatible 2.2+
+  builds. Version 2.1.x triggers the `auto` XWayland fallback or fails without
+  `DISPLAY`.
+- `CLIPASTE_BACKEND=wayland` requires native data-control access and fails instead
+  of falling back. `CLIPASTE_BACKEND=x11` requires `xclip` and an accessible
+  `DISPLAY`. Apply the same override to the daemon and `doctor`.
+- No display fails with guidance to run from a graphical desktop or configure a
+  consumer. Wayland-only without data-control fails with guidance to use an
+  XWayland clipboard bridge (`xclip` + `DISPLAY`) or an X11 session. No forced-focus
+  polling or popup workaround is used.
+- GNOME Wayland may need the XWayland clipboard bridge. Reporters must test a
+  screenshot copied from a native Wayland app, re-run `doctor`, and verify the
+  image fetched by `clipaste-paste` in a new SSH session. An X11-only test does
+  not prove native Wayland support; universal compatibility has not been tested.
+- Linux polls every 300 ms: clipboard `image/png` -> private stable PNG cache ->
+  existing loopback HTTP -> SSH shims / `clipaste-paste`. It adds no file URLs
+  or text to the clipboard and makes no promise of local terminal text-path
+  paste. Image file-copy offering only a URI is not supported yet.
+- Clipboard clears, non-image content, and recognized private markers clear the
+  staged image; historical cached paths remain. The cache is private (`0700`
+  directories, `0600` files) and has no automatic expiry.
+- Existing macOS/Windows paste workflows are unchanged. Linux verification
+  does not establish macOS/Windows regression coverage.
 
 ## Paste gesture by tool and location
 
@@ -62,30 +116,44 @@ Never press Cmd+V inside an SSH session — it sends the local file path as text
 Exit code: 0 usable (including warnings), 1 broken, 2 bad arguments. All setup
 commands are non-interactive and idempotent.
 
-The `unsupported-host` extension reports `fail` (exit 1) for an unsupported local
-machine without WSL context, an SSH session, or a configured consumer helper.
-Its `platform` check gives guidance in `detail` with `fix: null`.
-WSL takes precedence over SSH. Actual SSH sessions, including SSH into macOS,
-remain `ssh-remote`; a configured Linux consumer also retains `ssh-remote` when
-SSH environment variables are absent.
+WSL takes precedence over SSH and remains a Windows consumer even with display
+variables. Actual SSH sessions, including SSH into macOS or graphical Linux,
+remain `ssh-remote`. Graphical local Linux is `clipboard-host`; configured
+headless Linux consumers retain `ssh-remote` without SSH environment variables.
+Headless Linux without consumer indicators gets `clipboard-host` diagnostics
+with a failing `backend` check and graphical-session guidance.
+`unsupported-host` remains in the contract for platforms without a backend;
+it is not a blanket Linux classification.
 
-`unsupported-host` is a capability failure, not a missing systemd service, PATH
-entry, or `curl` dependency. To use Linux as a consumer, run `ssh-setup` on the
-Mac or Windows clipboard host with its daemon running, then open a new SSH
-session. WSL2 requires the Windows daemon and `wsl-setup` inside the distro.
-No command enables a native Linux clipboard backend.
+Run Linux host diagnostics as the same desktop user/session as the daemon:
+Wayland needs `WAYLAND_DISPLAY` and `XDG_RUNTIME_DIR`; X11/XWayland needs `DISPLAY`
+and display authorization. Preserve the same `CLIPASTE_BACKEND`. SSH, `sudo`,
+stale tmux sessions, and services can lack this context. Setting a display
+variable alone does not grant access. Follow the reported tool/session/protocol
+remedy; neither installing `curl` nor adding a service supplies desktop access.
+An empty clipboard warning is normal before copying a screenshot.
 
 ## Key facts
 
-- Written in Rust, ~1,600 lines, no runtime dependencies beyond OS clipboard APIs
-- ~9 MB resident memory, no measurable idle CPU
+- Written in Rust; Linux requires system clipboard tools, and CLI HTTP uses `curl`
+- Existing macOS/Windows footprint: ~9 MB resident memory, no measurable idle CPU;
+  this is not a Linux measurement, since Linux polls and invokes system tools
 - macOS: NSPasteboard change-counter watcher. Windows: event-driven via `AddClipboardFormatListener`, no polling
+- Linux: read-only PNG polling every 300 ms; does not rewrite clipboard formats
 - HTTP server binds to `127.0.0.1` only and is never exposed to the network
 - Screenshots use stable local SHA-256 cache paths with no automatic expiry;
   identical images reuse a path. Storage grows with unique images, and manual
   deletion invalidates saved paths.
 - WSL2 host detection probes candidate addresses rather than reading `/etc/resolv.conf` alone, so `networkingMode=mirrored` and NAT both work
 - Terminals: Ghostty, Alacritty, iTerm2, Terminal.app, WezTerm, Kitty, Windows Terminal
+
+## Opt-in Linux verification
+
+Run `bash tests/linux/run.sh` from the repository root on Linux for real
+clipboard-tool tests in isolated Xvfb/headless Sway sessions. Tests use temporary
+HOME/cache/runtime directories, not the real user's clipboard. See `AGENTS.md`
+for prerequisites and the `tests/linux/Dockerfile` container recipe. This does
+not replace testing a screenshot from a native app on the reporter's compositor.
 
 ## Links
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,14 @@
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
 use image::codecs::png::PngEncoder;
-use image::{ImageEncoder, ImageFormat};
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
+use image::ImageEncoder;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use image::ImageFormat;
 use sha2::{Digest, Sha256};
 use std::fs;
-use std::io::{self, Cursor, Write};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use std::io::Cursor;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -12,17 +18,15 @@ pub const VERSION: &str = "2.4.2";
 pub const DEFAULT_PORT: u16 = 18340;
 
 pub fn supports_clipboard_host(os: &str) -> bool {
-    matches!(os, "macos" | "windows")
+    matches!(os, "macos" | "windows" | "linux")
 }
 
 pub fn unsupported_host_message(os: &str) -> String {
-    let name = if os == "linux" { "Linux" } else { os };
     format!(
-        "{name} clipboard host is not supported. The daemon requires macOS or Windows.\n\
+        "{os} clipboard host is not supported. The daemon requires macOS, Windows, or a Linux desktop.\n\
          Linux is supported as an SSH consumer: run `clipaste ssh-setup user@host` on \
-         the macOS/Windows clipboard host, then use `clipaste-paste` on the remote.\n\
+         the clipboard host, then use `clipaste-paste` on the remote.\n\
          In WSL2, run `clipaste wsl-setup` with clipaste.exe running on Windows.\n\
-         Installing the Rust binary does not add a Linux clipboard backend.\n\
          See https://github.com/hqhq1025/clipaste#supported-platforms"
     )
 }
@@ -314,6 +318,7 @@ fn save_png_in_dir(dir: &Path, png_data: &[u8]) -> io::Result<PathBuf> {
 /// Kept for existing callers. Published PNGs have no automatic expiry because
 /// external clipboard histories retain their paths. Remove them explicitly to
 /// reclaim disk space; interrupted staging files may also be removed manually.
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
 pub fn clean_old_temp_files() {}
 
 /// Convert TIFF bytes to PNG bytes
@@ -422,7 +427,7 @@ pub fn print_help() {
         "clipaste v{VERSION} — Fix screenshot paste in terminals (local + SSH + WSL2)
 
 USAGE
-  clipaste                       Run daemon (macOS/Windows clipboard host only)
+  clipaste                       Run daemon (macOS, Windows, Linux desktop)
   clipaste doctor [--json]       Diagnose this machine and print the fix command
   clipaste ssh-setup user@host   Configure remote server for image paste via SSH
                                  (add -p PORT for a custom SSH port)
@@ -443,7 +448,8 @@ FOR CODING AGENTS
 
 WHAT IT DOES
   Local:  Watches the clipboard. When a screenshot is detected, saves it as
-          a temp PNG and registers the file path. Cmd+V / Ctrl+V just work.
+          a cached PNG. macOS/Windows also register the file path for pasting.
+          Linux reads image/png without modifying the clipboard.
 
   SSH:    Runs an HTTP server on port {DEFAULT_PORT}. Use 'ssh-setup' to
           configure SSH RemoteForward + xclip shim on a remote server.
@@ -456,14 +462,17 @@ WHAT IT DOES
           networking modes both work); override it with --host IP if needed.
 
 COMPATIBILITY
-  Host:    macOS and Windows only; native Linux clipboard hosts are unsupported
+  Host:    macOS, Windows, Linux desktop (Wayland data-control or X11/XWayland)
   macOS:   Ghostty, Alacritty, iTerm2, Terminal.app, WezTerm, Kitty
   Windows: Windows Terminal, PowerShell, cmd.exe
-  Remote:  Linux and macOS via SSH from a macOS/Windows clipboard host
+  Remote:  Linux and macOS via SSH from a supported clipboard host
   WSL2:    Consumer only; requires clipaste.exe running on Windows
 
-  Building/installing this binary on Linux provides doctor and setup commands,
-  not a local clipboard watcher. Run ssh-setup on the macOS/Windows host.
+  Linux:   Install wl-clipboard 2.2+ for native Wayland, or xclip
+           for X11/XWayland, plus curl. Run inside your graphical session.
+           Auto mode warns before using XWayland if data-control is unavailable.
+           CLIPASTE_BACKEND=wayland or x11 selects a backend explicitly.
+           No local text-path injection; SSH consumers use the existing helpers.
 
 MORE INFO
   https://github.com/hqhq1025/clipaste"

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -103,28 +103,42 @@ pub fn detect_role() -> Role {
         is_wsl(),
         is_ssh_session(),
         installed_helper_url(&home().join(".local/bin/clipaste-paste")).is_some(),
+        graphical_session(),
     )
 }
 
-fn classify_role(os: &str, wsl: bool, ssh: bool, configured_consumer: bool) -> Role {
+fn graphical_session() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        crate::linux::has_display()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
+}
+
+fn classify_role(os: &str, wsl: bool, ssh: bool, configured_consumer: bool, graphical: bool) -> Role {
     if os == "linux" && wsl {
         return Role::Wsl2;
     }
     if ssh {
         return Role::SshRemote;
     }
+    if os == "linux" && configured_consumer && !graphical {
+        return Role::SshRemote;
+    }
     if common::supports_clipboard_host(os) {
         Role::ClipboardHost
     } else if configured_consumer {
-        // A configured Linux consumer may be used outside the original SSH
-        // session (for example from tmux); let bridge checks diagnose its tunnel.
+        // Other unsupported platforms can still use the HTTP consumer helper.
         Role::SshRemote
     } else {
         Role::UnsupportedHost
     }
 }
 
-fn is_wsl() -> bool {
+pub(crate) fn is_wsl() -> bool {
     if std::env::var_os("WSL_DISTRO_NAME").is_some() || std::env::var_os("WSL_INTEROP").is_some() {
         return true;
     }
@@ -301,19 +315,31 @@ fn curl_install_hint() -> &'static str {
     }
 }
 
-fn daemon_start_hint() -> &'static str {
+pub(crate) fn daemon_start_hint() -> &'static str {
     if cfg!(target_os = "macos") {
         "brew services start clipaste"
     } else if cfg!(target_os = "windows") {
         "start clipaste.exe (reinstall: irm https://raw.githubusercontent.com/hqhq1025/clipaste/main/install.ps1 | iex)"
     } else {
-        "clipaste"
+        "run clipaste in your Linux graphical desktop session; leave it running"
     }
 }
 
 fn clipboard_host_checks() -> Vec<Check> {
     let base = format!("http://127.0.0.1:{}", common::DEFAULT_PORT);
     let mut checks = Vec::new();
+
+    #[cfg(target_os = "linux")]
+    match crate::linux::detect() {
+        Ok(backend) => {
+            if let Some(warning) = backend.warning {
+                checks.push(Check::warn("backend", format!("{}; {warning}", backend.detail)));
+            } else {
+                checks.push(Check::ok("backend", backend.detail));
+            }
+        }
+        Err(e) => return vec![Check::fail("backend", e)],
+    }
 
     match common::http_get(&format!("{base}/health")) {
         Some(body) if is_clipaste_health(&body) => {
@@ -561,19 +587,21 @@ mod tests {
     #[test]
     fn native_linux_is_not_assumed_to_be_an_ssh_remote() {
         assert_eq!(
-            classify_role("linux", false, false, false),
-            Role::UnsupportedHost
+            classify_role("linux", false, false, false, false),
+            Role::ClipboardHost
         );
     }
 
     #[test]
     fn role_detection_preserves_existing_consumers_and_supported_hosts() {
-        assert_eq!(classify_role("linux", false, true, false), Role::SshRemote);
-        assert_eq!(classify_role("linux", false, false, true), Role::SshRemote);
-        assert_eq!(classify_role("linux", true, true, true), Role::Wsl2);
-        assert_eq!(classify_role("macos", false, true, true), Role::SshRemote);
-        assert_eq!(classify_role("macos", false, false, true), Role::ClipboardHost);
-        assert_eq!(classify_role("windows", true, false, true), Role::ClipboardHost);
+        assert_eq!(classify_role("linux", false, true, false, true), Role::SshRemote);
+        assert_eq!(classify_role("linux", false, false, true, false), Role::SshRemote);
+        assert_eq!(classify_role("linux", false, false, true, true), Role::ClipboardHost);
+        assert_eq!(classify_role("linux", true, true, true, true), Role::Wsl2);
+        assert_eq!(classify_role("macos", false, true, true, true), Role::SshRemote);
+        assert_eq!(classify_role("macos", false, false, true, true), Role::ClipboardHost);
+        assert_eq!(classify_role("windows", true, false, true, true), Role::ClipboardHost);
+        assert_eq!(classify_role("freebsd", false, false, false, false), Role::UnsupportedHost);
     }
 
     #[test]
@@ -586,7 +614,7 @@ mod tests {
         let json = render_json(&report);
         assert!(json.contains("\"role\":\"unsupported-host\""));
         assert!(json.contains("\"status\":\"fail\""));
-        assert!(json.contains("macOS or Windows"));
+        assert!(json.contains("macOS, Windows, or a Linux desktop"));
         let human = render_human(&report);
         assert!(human.contains("clipaste ssh-setup"));
         assert!(!human.contains("run the → commands"));

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -27,7 +27,9 @@ extern "C" fn stop_signal(_: libc::c_int) {
 pub fn install_signal_handlers() -> io::Result<()> {
     for signal in [libc::SIGINT, libc::SIGTERM] {
         // SAFETY: the handler only sets an atomic flag; normal code owns cleanup.
-        if unsafe { libc::signal(signal, stop_signal as libc::sighandler_t) } == libc::SIG_ERR {
+        if unsafe { libc::signal(signal, stop_signal as *const () as libc::sighandler_t) }
+            == libc::SIG_ERR
+        {
             return Err(io::Error::last_os_error());
         }
     }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,540 @@
+//! Read the desktop clipboard without taking ownership or modifying its formats.
+//! The system tools implement the selection protocols, including X11 INCR.
+
+use crate::common::{self, LatestImage};
+use std::ffi::OsStr;
+use std::fs;
+use std::io::{self, Read};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+const TIMEOUT: Duration = Duration::from_secs(3);
+const POLL_INTERVAL: Duration = Duration::from_millis(300);
+const MAX_PNG: usize = 64 * 1024 * 1024;
+const MAX_TYPES: usize = 64 * 1024;
+static STOP: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn stop_signal(_: libc::c_int) {
+    STOP.store(true, Ordering::Relaxed);
+}
+
+pub fn install_signal_handlers() -> io::Result<()> {
+    for signal in [libc::SIGINT, libc::SIGTERM] {
+        // SAFETY: the handler only sets an atomic flag; normal code owns cleanup.
+        if unsafe { libc::signal(signal, stop_signal as libc::sighandler_t) } == libc::SIG_ERR {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Kind {
+    Wayland,
+    X11,
+}
+
+pub struct Backend {
+    kind: Kind,
+    program: PathBuf,
+    pub detail: String,
+    pub warning: Option<String>,
+}
+
+pub fn has_display() -> bool {
+    nonempty_env("WAYLAND_DISPLAY") || nonempty_env("DISPLAY")
+}
+
+fn nonempty_env(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|s| !s.is_empty())
+}
+
+/// Resolve the real desktop tool, never the HTTP consumer shim installed by us.
+fn desktop_tool(name: &str) -> Result<PathBuf, String> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        let executable = fs::metadata(&candidate)
+            .is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0);
+        if !executable {
+            continue;
+        }
+        let mut header = Vec::new();
+        if fs::File::open(&candidate)
+            .and_then(|file| file.take(4096).read_to_end(&mut header))
+            .is_err()
+        {
+            continue;
+        }
+        if String::from_utf8_lossy(&header).contains("CLIPASTE_URL=") {
+            continue;
+        }
+        return fs::canonicalize(&candidate).map_err(|e| format!("{name}: {e}"));
+    }
+    let package = match name {
+        "wl-paste" => "wl-clipboard",
+        _ => name,
+    };
+    Err(format!(
+        "{name} not found (clipaste consumer shims do not count). \
+         Install {package} with your package manager, e.g. sudo apt install {package}"
+    ))
+}
+
+pub fn detect() -> Result<Backend, String> {
+    let requested = std::env::var("CLIPASTE_BACKEND").unwrap_or_else(|_| "auto".into());
+    if !matches!(requested.as_str(), "auto" | "wayland" | "x11") {
+        return Err("CLIPASTE_BACKEND must be auto, wayland, or x11".into());
+    }
+    if !has_display() {
+        return Err(
+            "No Linux graphical session: WAYLAND_DISPLAY and DISPLAY are unset. \
+             Start clipaste from your desktop session, not a headless SSH shell. \
+             For a remote consumer, run ssh-setup on the clipboard host."
+                .into(),
+        );
+    }
+    let mut wayland_error = None;
+    if requested != "x11" && (nonempty_env("WAYLAND_DISPLAY") || requested == "wayland") {
+        match wayland_backend() {
+            Ok(backend) => return Ok(backend),
+            Err(e) if requested == "wayland" => return Err(e),
+            Err(e) => wayland_error = Some(e),
+        }
+    }
+    if nonempty_env("DISPLAY") {
+        let backend = (|| {
+            let program = desktop_tool("xclip")?;
+            let backend = Backend {
+                kind: Kind::X11,
+                detail: format!("X11 clipboard via {}", program.display()),
+                program,
+                warning: wayland_error.clone().map(|e| {
+                    format!(
+                        "Native Wayland unavailable: {e}. Using XWayland via DISPLAY; \
+                         this relies on your compositor's clipboard bridge. \
+                         Verify a screenshot from your Wayland app with clipaste doctor."
+                    )
+                }),
+            };
+            backend.types()?;
+            Ok(backend)
+        })();
+        return backend.map_err(|e: String| match wayland_error {
+            Some(w) => format!("Wayland: {w}\nXWayland: {e}"),
+            None => e,
+        });
+    }
+    Err(wayland_error
+        .unwrap_or_else(|| "X11 requires DISPLAY. Run clipaste in a graphical X11 session.".into()))
+}
+
+fn wayland_backend() -> Result<Backend, String> {
+    let program = desktop_tool("wl-paste")?;
+    let version = command_output(&program, &["--version"], MAX_TYPES, TIMEOUT)?;
+    if !version.status.success() || !supports_empty_events(&version.stdout) {
+        return Err(
+            "Wayland requires wl-clipboard 2.2 or later for empty-selection events. \
+            Upgrade wl-clipboard or use XWayland (xclip + DISPLAY)."
+                .into(),
+        );
+    }
+    let backend = Backend {
+        kind: Kind::Wayland,
+        detail: format!("Wayland data-control clipboard via {}", program.display()),
+        program,
+        warning: None,
+    };
+    backend.types().map_err(|e| {
+        format!(
+            "Wayland background clipboard access failed: {e}. \
+         wl-paste must support the compositor's data-control protocol \
+         (ext-only compositors need wl-clipboard 2.3+ built with ext support). \
+         Use XWayland (xclip + DISPLAY) or an X11 session if unavailable."
+        )
+    })?;
+    Ok(backend)
+}
+
+fn supports_empty_events(version: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(version);
+    let Some(number) = text.split_whitespace().nth(1) else {
+        return false;
+    };
+    let mut parts = number.split('.');
+    matches!((parts.next().and_then(|n| n.parse::<u32>().ok()),
+              parts.next().and_then(|n| n.parse::<u32>().ok())),
+             (Some(major), Some(minor)) if major > 2 || (major == 2 && minor >= 2))
+}
+
+fn offers_png(types: &str) -> bool {
+    let types: Vec<_> = types.lines().map(str::trim).collect();
+    // Respect clipboard-history exclusions before requesting image bytes.
+    !types.iter().any(|t| {
+        matches!(
+            *t,
+            "x-kde-passwordManagerHint"
+                | "application/x-keepassxc"
+                | "application/x-clipman-ignore"
+        )
+    }) && types.contains(&"image/png")
+}
+
+impl Backend {
+    fn success(&self, out: &CommandOutput) -> bool {
+        out.status.success()
+            || (self.kind == Kind::Wayland && out.status.signal() == Some(libc::SIGTERM))
+    }
+
+    fn types(&self) -> Result<String, String> {
+        let args: &[&str] = match self.kind {
+            // --watch refuses compositors lacking data-control instead of
+            // creating a popup. For an empty selection, stop after its callback;
+            // for nonempty selections, --list-types prints and exits itself.
+            Kind::Wayland => &[
+                "--list-types",
+                "--watch",
+                "/bin/sh",
+                "-c",
+                "kill -TERM \"$PPID\"",
+            ],
+            Kind::X11 => &["-selection", "clipboard", "-t", "TARGETS", "-o"],
+        };
+        let out = command_output(&self.program, args, MAX_TYPES, TIMEOUT)?;
+        if self.success(&out) {
+            return String::from_utf8(out.stdout).map_err(|_| "Invalid clipboard type list".into());
+        }
+        let error = out.error();
+        let empty = match self.kind {
+            Kind::Wayland => matches!(error.trim(), "Nothing is copied" | "No selection"),
+            Kind::X11 => error.trim() == "Error: target TARGETS not available",
+        };
+        if empty {
+            Ok(String::new())
+        } else {
+            Err(format!("{}: {error}", self.program.display()))
+        }
+    }
+
+    pub fn read_png(&self) -> Result<Option<Vec<u8>>, String> {
+        if !offers_png(&self.types()?) {
+            return Ok(None);
+        }
+        let args: &[&str] = match self.kind {
+            // One complete transfer in no-popup watch mode. Stop the watcher
+            // only after cat has finished writing the PNG to our bounded pipe.
+            Kind::Wayland => &[
+                "--no-newline",
+                "--type",
+                "image/png",
+                "--watch",
+                "/bin/sh",
+                "-c",
+                "/bin/cat; kill -TERM \"$PPID\"",
+            ],
+            Kind::X11 => &["-selection", "clipboard", "-t", "image/png", "-o"],
+        };
+        let out = match command_output(&self.program, args, MAX_PNG, TIMEOUT) {
+            Err(e) if e.contains("output exceeds the size limit") => return Ok(None),
+            result => result?,
+        };
+        if !self.success(&out) {
+            return Err(format!("Clipboard image read failed: {}", out.error()));
+        }
+        // Selection transfers can race a copy of text or a privacy-marked item.
+        if !offers_png(&self.types()?) {
+            return Ok(None);
+        }
+        Ok(Some(out.stdout))
+    }
+}
+
+fn validate_png(bytes: &[u8]) -> Result<(), String> {
+    let mut reader =
+        image::ImageReader::with_format(io::Cursor::new(bytes), image::ImageFormat::Png);
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(16384);
+    limits.max_image_height = Some(16384);
+    limits.max_alloc = Some(128 * 1024 * 1024);
+    reader.limits(limits);
+    reader
+        .decode()
+        .map_err(|e| format!("Invalid or oversized clipboard PNG: {e}"))?;
+    Ok(())
+}
+
+/// `save` is injected to keep transition tests off the user's persistent cache.
+fn stage(
+    latest: &LatestImage,
+    png: Option<&[u8]>,
+    previous: &mut Option<Vec<u8>>,
+    save: impl FnOnce(&[u8]) -> Option<PathBuf>,
+) -> Result<(), String> {
+    let published = latest.lock().unwrap().clone();
+    if png == previous.as_deref()
+        && (png.is_none() || published.as_ref().is_some_and(|p| p.is_file()))
+    {
+        return Ok(());
+    }
+    *latest.lock().unwrap() = None;
+    *previous = None;
+    if let Some(bytes) = png {
+        let path = save(bytes).ok_or("Cannot publish the clipboard PNG cache")?;
+        *latest.lock().unwrap() = Some(path);
+        *previous = Some(bytes.to_vec());
+    }
+    Ok(())
+}
+
+pub fn run(backend: Backend, latest: LatestImage) -> Result<(), String> {
+    common::log(&backend.detail);
+    if let Some(warning) = &backend.warning {
+        common::log(warning);
+    }
+    let mut previous = None;
+    let mut rejected = None;
+    let mut failures = 0;
+    while !STOP.load(Ordering::Relaxed) {
+        let result = backend.read_png().and_then(|mut png| {
+            if let Some(bytes) = &png {
+                if rejected.as_ref() == Some(bytes) {
+                    png = None;
+                } else if previous.as_ref() == Some(bytes) {
+                    rejected = None;
+                } else if let Err(e) = validate_png(bytes) {
+                    if rejected.as_ref() != Some(bytes) {
+                        common::log(&e);
+                    }
+                    rejected = png.take();
+                } else {
+                    rejected = None;
+                }
+            }
+            stage(
+                &latest,
+                png.as_deref(),
+                &mut previous,
+                common::save_png_to_temp,
+            )
+        });
+        match result {
+            Ok(()) => failures = 0,
+            Err(e) => {
+                if STOP.load(Ordering::Relaxed) {
+                    break;
+                }
+                *latest.lock().unwrap() = None;
+                previous = None;
+                failures += 1;
+                common::log(&e);
+                if failures >= 3 {
+                    return Err("Clipboard access failed three times; stopping the daemon. \
+                        Check the desktop session and run clipaste doctor before restarting."
+                        .into());
+                }
+            }
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    *latest.lock().unwrap() = None;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct CommandOutput {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+impl CommandOutput {
+    fn error(&self) -> String {
+        let error = String::from_utf8_lossy(&self.stderr);
+        if error.trim().is_empty() {
+            format!("exited with {}", self.status)
+        } else {
+            error.trim().to_string()
+        }
+    }
+}
+
+struct ChildGroup(Child);
+
+impl Drop for ChildGroup {
+    fn drop(&mut self) {
+        // SAFETY: process_group(0) made this child the leader of its own group.
+        // Kill descendants too: wl-paste delegates the actual pipe read to cat.
+        unsafe { libc::kill(-(self.0.id() as i32), libc::SIGKILL) };
+        let _ = self.0.wait();
+    }
+}
+
+fn nonblocking(fd: RawFd) -> io::Result<()> {
+    // SAFETY: fd belongs to a live child pipe; no pointer arguments are involved.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn drain(pipe: &mut impl Read, bytes: &mut Vec<u8>, limit: usize) -> io::Result<bool> {
+    let mut buf = [0; 8192];
+    // Yield even when a producer never closes its pipe, so timeout/stderr are
+    // checked and one busy pipe cannot starve the other.
+    for _ in 0..32 {
+        match pipe.read(&mut buf) {
+            Ok(0) => return Ok(true),
+            Ok(n) => {
+                if bytes.len() + n > limit {
+                    return Err(io::Error::other(
+                        "clipboard command output exceeds the size limit",
+                    ));
+                }
+                bytes.extend_from_slice(&buf[..n]);
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => return Ok(false),
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(false)
+}
+
+fn command_output(
+    program: impl AsRef<OsStr>,
+    args: &[&str],
+    limit: usize,
+    timeout: Duration,
+) -> Result<CommandOutput, String> {
+    let mut child = ChildGroup(
+        Command::new(program)
+            .args(args)
+            .env("LC_ALL", "C")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0)
+            .spawn()
+            .map_err(|e| e.to_string())?,
+    );
+    let mut stdout = child.0.stdout.take().unwrap();
+    let mut stderr = child.0.stderr.take().unwrap();
+    nonblocking(stdout.as_raw_fd()).map_err(|e| e.to_string())?;
+    nonblocking(stderr.as_raw_fd()).map_err(|e| e.to_string())?;
+    let start = Instant::now();
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    loop {
+        let out_done = drain(&mut stdout, &mut out, limit).map_err(|e| e.to_string())?;
+        let err_done = drain(&mut stderr, &mut err, MAX_TYPES).map_err(|e| e.to_string())?;
+        if out_done && err_done {
+            if let Some(status) = child.0.try_wait().map_err(|e| e.to_string())? {
+                return Ok(CommandOutput {
+                    status,
+                    stdout: out,
+                    stderr: err,
+                });
+            }
+        }
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "Clipboard command timed out after {} ms",
+                timeout.as_millis()
+            ));
+        }
+        if STOP.load(Ordering::Relaxed) {
+            return Err("Clipboard read interrupted".into());
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_and_sensitive_types_are_explicit() {
+        assert!(offers_png("TARGETS\nimage/png\ntext/html\ntext/plain\n"));
+        assert!(!offers_png("image/png\nx-kde-passwordManagerHint\n"));
+        assert!(!offers_png("text/uri-list\n"));
+        assert!(!supports_empty_events(b"wl-paste 2.1.0"));
+        assert!(supports_empty_events(b"wl-paste 2.2.1"));
+        assert!(supports_empty_events(b"wl-paste 2.3.0"));
+    }
+
+    #[test]
+    fn transitions_deduplicate_clear_and_retry_cache_failures() {
+        let latest = LatestImage::default();
+        let mut previous = None;
+        stage(&latest, Some(b"a"), &mut previous, |_| {
+            Some(std::env::current_exe().unwrap())
+        })
+        .unwrap();
+        stage(&latest, Some(b"a"), &mut previous, |_| {
+            panic!("duplicate write")
+        })
+        .unwrap();
+        assert_eq!(
+            *latest.lock().unwrap(),
+            Some(std::env::current_exe().unwrap())
+        );
+        stage(&latest, None, &mut previous, |_| panic!("non-image write")).unwrap();
+        assert!(latest.lock().unwrap().is_none());
+        assert!(stage(&latest, Some(b"b"), &mut previous, |_| None).is_err());
+        assert!(latest.lock().unwrap().is_none());
+        stage(&latest, Some(b"b"), &mut previous, |_| {
+            Some(PathBuf::from("b"))
+        })
+        .unwrap();
+        assert_eq!(*latest.lock().unwrap(), Some(PathBuf::from("b")));
+    }
+
+    #[test]
+    fn rejects_corrupt_or_mislabeled_images() {
+        assert!(validate_png(b"not a png").is_err());
+        let mut png = Vec::new();
+        use image::ImageEncoder;
+        image::codecs::png::PngEncoder::new(&mut png)
+            .write_image(&[1, 2, 3, 255], 1, 1, image::ExtendedColorType::Rgba8)
+            .unwrap();
+        validate_png(&png).unwrap();
+        assert!(validate_png(&png[..png.len() / 2]).is_err());
+    }
+
+    #[test]
+    fn commands_have_bounded_time_and_output_even_with_descendants() {
+        let start = Instant::now();
+        assert!(command_output(
+            "/bin/sh",
+            &["-c", "sleep 30 & wait"],
+            1024,
+            Duration::from_millis(50)
+        )
+        .unwrap_err()
+        .contains("timed out"));
+        assert!(start.elapsed() < Duration::from_secs(2));
+        assert!(
+            command_output("/bin/sh", &["-c", "printf 12345"], 4, TIMEOUT)
+                .unwrap_err()
+                .contains("size limit")
+        );
+        let out = command_output(
+            "/bin/sh",
+            &["-c", "printf ok; printf error >&2; exit 7"],
+            10,
+            TIMEOUT,
+        )
+        .unwrap();
+        assert_eq!(out.stdout, b"ok");
+        assert_eq!(out.error(), "error");
+        assert_eq!(out.status.code(), Some(7));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod common;
 mod doctor;
+#[cfg(target_os = "linux")]
+mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
 mod server;
@@ -62,9 +64,21 @@ fn main() {
     // Reject unsupported hosts before starting a listener or touching the cache.
     require_clipboard_host();
 
+    #[cfg(target_os = "linux")]
+    let backend = linux::install_signal_handlers()
+        .map_err(|e| e.to_string())
+        .and_then(|_| linux::detect())
+        .unwrap_or_else(|e| {
+            eprintln!("clipaste: {e}");
+            std::process::exit(1);
+        });
+
     // Start HTTP server for remote access
     let latest = common::LatestImage::default();
-    server::start(latest.clone());
+    if let Err(e) = server::start(latest.clone()) {
+        eprintln!("clipaste: cannot start HTTP server: {e}");
+        std::process::exit(1);
+    }
 
     // Start clipboard watcher (platform-specific)
     #[cfg(target_os = "macos")]
@@ -72,12 +86,26 @@ fn main() {
 
     #[cfg(target_os = "windows")]
     windows::run(latest);
+
+    #[cfg(target_os = "linux")]
+    if let Err(e) = linux::run(backend, latest) {
+        eprintln!("clipaste: {e}");
+        std::process::exit(1);
+    }
 }
 
 fn require_clipboard_host() {
     let os = std::env::consts::OS;
     if !common::supports_clipboard_host(os) {
         eprintln!("clipaste: {}", common::unsupported_host_message(os));
+        std::process::exit(1);
+    }
+    #[cfg(target_os = "linux")]
+    if doctor::is_wsl() {
+        eprintln!(
+            "clipaste: WSL2 is a clipboard consumer. Run clipaste.exe on Windows \
+            and clipaste wsl-setup inside WSL2."
+        );
         std::process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,12 @@ fn main() {
         return;
     }
 
+    #[cfg(target_os = "linux")]
+    if let Err(e) = linux::install_signal_handlers() {
+        eprintln!("clipaste: cannot install stop handlers: {e}");
+        std::process::exit(1);
+    }
+
     // clipaste doctor [--json] — diagnose this machine and print the fix
     if args.len() >= 2 && args[1] == "doctor" {
         let json = args[2..].iter().any(|a| a == "--json");
@@ -65,13 +71,10 @@ fn main() {
     require_clipboard_host();
 
     #[cfg(target_os = "linux")]
-    let backend = linux::install_signal_handlers()
-        .map_err(|e| e.to_string())
-        .and_then(|_| linux::detect())
-        .unwrap_or_else(|e| {
-            eprintln!("clipaste: {e}");
-            std::process::exit(1);
-        });
+    let backend = linux::detect().unwrap_or_else(|e| {
+        eprintln!("clipaste: {e}");
+        std::process::exit(1);
+    });
 
     // Start HTTP server for remote access
     let latest = common::LatestImage::default();

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,23 +4,19 @@ use std::net::TcpListener;
 
 /// Start HTTP server in a background thread.
 /// Serves the latest screenshot PNG on GET /clipboard/image.
-pub fn start(latest: LatestImage) {
+pub fn start(latest: LatestImage) -> std::io::Result<()> {
+    let addr = format!("127.0.0.1:{}", common::DEFAULT_PORT);
+    // Bind before the watcher starts, so a stale daemon/tunnel cannot be mistaken
+    // for this process's successfully published clipboard.
+    let listener = TcpListener::bind(&addr)?;
+    common::log(&format!("http server listening on {addr}"));
     std::thread::spawn(move || {
-        let addr = format!("127.0.0.1:{}", common::DEFAULT_PORT);
-        let listener = match TcpListener::bind(&addr) {
-            Ok(l) => l,
-            Err(e) => {
-                common::log(&format!("http server failed to bind {addr}: {e}"));
-                return;
-            }
-        };
-        common::log(&format!("http server listening on {addr}"));
-
         for stream in listener.incoming().flatten() {
             let latest = latest.clone();
             std::thread::spawn(move || handle_request(stream, latest));
         }
     });
+    Ok(())
 }
 
 fn handle_request(mut stream: std::net::TcpStream, latest: LatestImage) {

--- a/src/ssh_setup.rs
+++ b/src/ssh_setup.rs
@@ -318,7 +318,7 @@ pub fn run_ssh(host: &str, ssh_port: Option<u16>) {
     if !check_health(&format!("http://127.0.0.1:{}", common::DEFAULT_PORT)) {
         println!("FAILED");
         eprintln!("  clipaste daemon is not running. Start it first:");
-        eprintln!("  brew services start clipaste");
+        eprintln!("  {}", crate::doctor::daemon_start_hint());
         std::process::exit(1);
     }
     println!("OK");
@@ -354,7 +354,7 @@ pub fn run_ssh(host: &str, ssh_port: Option<u16>) {
     println!();
     println!("Setup complete!");
     println!("  1. Open a NEW SSH session: ssh {host}");
-    println!("  2. Take a screenshot (or copy an image file) on your Mac");
+    println!("  2. Copy a screenshot/image to the clipboard on your local computer");
     if remote_os == "Darwin" {
         // macOS remote: xclip/wl-paste don't apply; tools read the *remote*
         // (empty) pasteboard. The clipaste-paste helper is the working path.
@@ -1142,4 +1142,3 @@ mod tests {
         let _ = std::fs::remove_dir_all(&home);
     }
 }
-

--- a/tests/linux/Dockerfile
+++ b/tests/linux/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.92-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb xclip sway wl-clipboard dbus-x11 python3-pil meson libwayland-dev wayland-protocols \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch v2.3.0 https://github.com/bugaevc/wl-clipboard /tmp/wl-clipboard \
+    && meson setup /tmp/wl-clipboard/build /tmp/wl-clipboard \
+    && ninja -C /tmp/wl-clipboard/build install \
+    && rm -rf /tmp/wl-clipboard
+RUN useradd -m -u 1000 tester
+RUN rustup component add clippy
+WORKDIR /work
+COPY . .
+RUN cargo test --locked --no-run && cargo build --locked \
+    && chown -R tester:tester /work
+USER tester
+ENV HOME=/home/tester
+CMD ["bash", "tests/linux/run.sh"]

--- a/tests/linux/run.sh
+++ b/tests/linux/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(mktemp -d)
+cleanup() {
+    if [[ -n "${sway_pid:-}" ]]; then kill "$sway_pid" 2>/dev/null || true; fi
+    if [[ -n "${xvfb_pid:-}" ]]; then kill "$xvfb_pid" 2>/dev/null || true; fi
+    rm -rf "$root"
+}
+trap cleanup EXIT
+
+cargo test --locked
+cargo clippy --locked --all-targets -- -D warnings
+cargo build --locked
+export CLIPASTE_TEST_BINARY="$PWD/target/debug/clipaste"
+export XDG_RUNTIME_DIR="$root/runtime"
+mkdir -m 700 "$XDG_RUNTIME_DIR"
+
+Xvfb -displayfd 3 -screen 0 1024x768x24 3>"$root/display" >"$root/xvfb.log" 2>&1 &
+xvfb_pid=$!
+for i in {1..100}; do
+    [[ -s "$root/display" ]] && break
+    sleep 0.05
+done
+export DISPLAY=":$(cat "$root/display")"
+/usr/bin/python3 tests/linux/smoke.py x11
+
+unset DISPLAY
+export WLR_BACKENDS=headless
+export WLR_LIBINPUT_NO_DEVICES=1
+export WLR_RENDERER=pixman
+dbus-run-session sway --unsupported-gpu -c /dev/null >"$root/sway.log" 2>&1 &
+sway_pid=$!
+for i in {1..100}; do
+    for socket in "$XDG_RUNTIME_DIR"/wayland-*; do
+        if [[ -S "$socket" ]]; then export WAYLAND_DISPLAY="${socket##*/}"; break 2; fi
+    done
+    sleep 0.05
+done
+if [[ -z "${WAYLAND_DISPLAY:-}" ]]; then cat "$root/sway.log"; exit 1; fi
+/usr/bin/python3 tests/linux/smoke.py wayland

--- a/tests/linux/smoke.py
+++ b/tests/linux/smoke.py
@@ -1,0 +1,176 @@
+"""Opt-in tests: run only in an isolated Xvfb/headless Wayland desktop."""
+
+import io
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+from PIL import Image
+
+
+mode = sys.argv[1]
+binary = os.environ["CLIPASTE_TEST_BINARY"]
+base = "http://127.0.0.1:18340"
+owners = []
+
+
+def get(path):
+    with urllib.request.urlopen(base + path, timeout=2) as response:
+        return response.status, response.read()
+
+
+def wait_for(predicate, detail):
+    deadline = time.monotonic() + 8
+    while time.monotonic() < deadline:
+        try:
+            if predicate():
+                return
+        except (OSError, urllib.error.URLError):
+            pass
+        time.sleep(0.03)
+    raise AssertionError(detail)
+
+
+def copy(data, mime="image/png", sensitive=False):
+    if mode == "x11":
+        args = ["xclip", "-selection", "clipboard", "-t", mime, "-i", "-quiet"]
+    else:
+        args = ["wl-copy", "--foreground", "--type", mime]
+        if sensitive:
+            args.append("--sensitive")
+    proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL, start_new_session=True)
+    owners.append(proc)
+    proc.stdin.write(data)
+    proc.stdin.close()
+
+
+def png(value):
+    data = io.BytesIO()
+    Image.new("RGBA", (37, 29), (value, 23, 42, 255)).save(data, format="PNG")
+    return data.getvalue()
+
+
+def stop(proc):
+    if proc.poll() is None:
+        os.killpg(proc.pid, signal.SIGTERM)
+    proc.wait(timeout=5)
+
+
+with tempfile.TemporaryDirectory(prefix="clipaste-smoke-") as temp:
+    env = dict(os.environ, HOME=temp, XDG_CACHE_HOME=temp + "/cache",
+               CLIPASTE_BACKEND=mode)
+    for key in ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY", "WSL_DISTRO_NAME", "WSL_INTEROP"]:
+        env.pop(key, None)
+    log = open(temp + "/daemon.log", "w+")
+    daemon = None
+    try:
+        first, second = png(11), png(99)
+        copy(first)
+        # Confirm the selection exists before testing capture at daemon startup.
+        reader = (["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
+                  if mode == "x11" else ["wl-paste", "--no-newline", "--type", "image/png"])
+        wait_for(lambda: subprocess.run(reader, stdout=subprocess.PIPE,
+                 stderr=subprocess.DEVNULL, timeout=3).stdout == first, "initial selection")
+        daemon = subprocess.Popen([binary], env=env, stdout=log, stderr=log,
+                                  start_new_session=True)
+        wait_for(lambda: get("/clipboard/image") == (200, first), "first PNG not served")
+        assert subprocess.check_output(reader) == first, "watcher modified clipboard"
+        health = json.loads(get("/health")[1])
+        assert health["status"] == "ok"
+        doctor = subprocess.run([binary, "doctor", "--json"], env=env,
+                                capture_output=True, timeout=15)
+        assert doctor.returncode == 0, doctor.stdout
+        report = json.loads(doctor.stdout)
+        assert report["role"] == "clipboard-host"
+        assert any(c["name"] == "backend" and c["status"] == "ok" for c in report["checks"])
+
+        # Use the shipped installer and consumer helper, with a second isolated
+        # HOME. Transport is container loopback here, not a claimed SSH test.
+        consumer_home = Path(temp) / "consumer"
+        consumer_home.mkdir()
+        consumer_env = dict(env, HOME=str(consumer_home), WSL_DISTRO_NAME="Test",
+                            TMPDIR=str(consumer_home))
+        setup = subprocess.run([binary, "wsl-setup", "--host", "127.0.0.1"],
+                               env=consumer_env, capture_output=True, timeout=15)
+        assert setup.returncode == 0, setup.stderr
+        helper = consumer_home / ".local/bin/clipaste-paste"
+        fetched = subprocess.check_output([str(helper)], env=consumer_env, timeout=10)
+        assert Path(fetched.decode().strip()).read_bytes() == first
+        # The host must bypass these generated HTTP shims even if they precede
+        # system tools on PATH, or the next copy would read its own cached PNG.
+        stop(daemon)
+        env["PATH"] = str(consumer_home / ".local/bin") + ":" + env["PATH"]
+        daemon = subprocess.Popen([binary], env=env, stdout=log, stderr=log,
+                                  start_new_session=True)
+        wait_for(lambda: get("/clipboard/image") == (200, first), "restart with shims")
+
+        duplicate = subprocess.run([binary], env=env, capture_output=True, timeout=10)
+        assert duplicate.returncode == 1
+        assert b"cannot start HTTP server" in duplicate.stderr
+        cache = Path(temp + "/cache/clipaste")
+        wait_for(lambda: len(list(cache.glob("*.png"))) == 1, "cache did not deduplicate")
+        original_path = next(cache.glob("*.png"))
+        original_time = original_path.stat().st_mtime_ns
+        copy(second)
+        wait_for(lambda: get("/clipboard/image") == (200, second), "replacement PNG not served")
+        copy(b"plain text", "text/plain")
+        wait_for(lambda: get("/clipboard/image")[0] == 204, "text left stale image")
+        assert json.loads(get("/clipboard/type")[1])["type"] == "empty"
+        assert original_path.read_bytes() == first, "historical image was deleted"
+        copy(first)
+        wait_for(lambda: get("/clipboard/image") == (200, first), "recopy not captured")
+        assert original_path.stat().st_mtime_ns == original_time
+        assert len(list(cache.glob("*.png"))) == 2
+        assert (cache.stat().st_mode & 0o777) == 0o700
+        assert all(p.stat().st_mode & 0o777 == 0o600 for p in cache.glob("*.png"))
+        original_path.unlink()
+        wait_for(lambda: original_path.exists() and get("/clipboard/image") == (200, first),
+                 "unchanged clipboard did not restore deleted cache")
+
+        copy(b"not actually a PNG")
+        wait_for(lambda: get("/clipboard/image")[0] == 204, "corrupt image left stale PNG")
+        # Hold bad contents beyond the former three-poll fatal-error threshold.
+        time.sleep(2)
+        assert daemon.poll() is None, "invalid content killed daemon"
+        copy(second)
+        wait_for(lambda: get("/clipboard/image") == (200, second), "read did not recover")
+
+        if mode == "wayland":
+            help_text = subprocess.check_output(["wl-copy", "--help"], stderr=subprocess.STDOUT)
+            if b"--sensitive" in help_text:
+                copy(second, sensitive=True)
+                wait_for(lambda: get("/clipboard/image")[0] == 204, "sensitive image was staged")
+            else:
+                print("wayland: wl-copy lacks --sensitive; marker filtering covered by unit tests")
+            subprocess.run(["wl-copy", "--clear"], check=True)
+            wait_for(lambda: get("/clipboard/image")[0] == 204, "clear left stale image")
+            time.sleep(2)
+            assert daemon.poll() is None, "empty clipboard killed daemon"
+            stop(daemon)
+            daemon = subprocess.Popen([binary], env=env, stdout=log, stderr=log,
+                                      start_new_session=True)
+            wait_for(lambda: get("/health")[0] == 200, "empty clipboard startup failed")
+            copy(first)
+            wait_for(lambda: get("/clipboard/image") == (200, first), "empty startup recovery")
+        print(f"{mode}: startup, HTTP, doctor, port conflict, replacement, text clearing, "
+              "deduplication, cache permissions, consumer helper, shim bypass "
+              "and clipboard preservation passed")
+    except BaseException:
+        log.flush()
+        log.seek(0)
+        print(log.read(), file=sys.stderr)
+        raise
+    finally:
+        if daemon is not None:
+            stop(daemon)
+        for owner in owners:
+            stop(owner)
+        log.close()

--- a/tests/linux_cli.rs
+++ b/tests/linux_cli.rs
@@ -5,6 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::{Command, Output};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 struct TestHome(PathBuf);
 
@@ -78,16 +79,18 @@ fn wsl_kernel() -> bool {
 }
 
 #[test]
-fn unsupported_daemon_and_host_setup_fail_before_side_effects() {
+fn headless_daemon_fails_before_side_effects() {
     let home = TestHome::new();
-    for args in [vec![], vec!["ssh-setup", "user@example.invalid"]] {
-        let out = home.command().args(args).output().unwrap();
+    {
+        let out = home.command().output().unwrap();
         assert_eq!(out.status.code(), Some(1));
         assert!(out.stdout.is_empty());
         let error = String::from_utf8(out.stderr).unwrap();
-        assert!(error.contains("Linux clipboard host is not supported"));
-        assert!(error.contains("macOS or Windows"));
-        assert!(error.contains("clipaste-paste"));
+        assert!(error.contains(if wsl_kernel() {
+            "WSL2 is a clipboard consumer"
+        } else {
+            "No Linux graphical session"
+        }));
         assert!(!error.contains("http server"));
         assert!(!error.contains("brew services start"));
         assert_eq!(fs::read_dir(&home.0).unwrap().count(), 0);
@@ -107,10 +110,9 @@ fn native_linux_or_wsl_doctor_reports_the_applicable_failure() {
         assert!(json.contains("\"name\":\"helper\""));
         assert!(!json.contains("\"name\":\"platform\""));
     } else {
-        assert!(json.contains("\"role\":\"unsupported-host\""));
-        assert!(json.contains("\"name\":\"platform\""));
+        assert!(json.contains("\"role\":\"clipboard-host\""));
+        assert!(json.contains("\"name\":\"backend\""));
         assert!(json.contains("\"fix\":null"));
-        assert!(!json.contains("\"name\":\"curl\""));
         assert!(!json.contains("\"name\":\"helper\""));
     }
     assert_eq!(fs::read_dir(&home.0).unwrap().count(), 0);
@@ -220,7 +222,7 @@ fn help_version_and_consumer_argument_validation_remain_available() {
         let out = home.command().arg(flag).output().unwrap();
         assert!(out.status.success());
         if flag == "--help" {
-            assert!(stdout(&out).contains("native Linux clipboard hosts are unsupported"));
+            assert!(stdout(&out).contains("Linux desktop"));
             assert!(stdout(&out).contains("wsl-setup"));
         }
     }
@@ -233,4 +235,174 @@ fn help_version_and_consumer_argument_validation_remain_available() {
     let error = String::from_utf8(out.stderr).unwrap();
     assert!(error.contains("unexpected argument"));
     assert!(!error.contains("clipboard host is not supported"));
+}
+
+#[test]
+fn desktop_backend_checks_dependencies_and_never_executes_consumer_shims() {
+    if wsl_kernel() {
+        return;
+    }
+    let home = TestHome::new();
+    home.script("xclip", "#!/bin/sh\nCLIPASTE_URL=\"http://127.0.0.1:18340\"\nprintf called > \"$HOME/shim-called\"\n");
+    let out = home
+        .command()
+        .env("DISPLAY", ":999")
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    assert!(stdout(&out).contains("consumer shims do not count"));
+    assert!(!home.0.join("shim-called").exists());
+    assert!(!home.0.join("cache").exists());
+}
+
+#[test]
+fn wayland_failure_and_xwayland_fallback_are_visible() {
+    if wsl_kernel() {
+        return;
+    }
+    let home = TestHome::new();
+    home.fake_curl();
+    home.script(
+        "wl-paste",
+        "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'wl-paste 2.3.0\\n'; exit 0; fi\n\
+         case \" $* \" in *' --watch '*) printf 'Watch mode requires data-control\\n' >&2; exit 1;; esac\n\
+         printf called > \"$HOME/unsafe-paste-called\"\n",
+    );
+    home.script("xclip", "#!/bin/sh\nprintf 'TARGETS\\ntext/plain\\n'\n");
+    let mut command = home.command();
+    command
+        .env("WAYLAND_DISPLAY", "wayland-test")
+        .env("DISPLAY", ":999");
+    let out = command.args(["doctor", "--json"]).output().unwrap();
+    assert!(out.status.success(), "{out:?}");
+    assert!(stdout(&out).contains("Using XWayland"));
+    assert!(!home.0.join("unsafe-paste-called").exists());
+    let out = home
+        .command()
+        .env("WAYLAND_DISPLAY", "wayland-test")
+        .env("DISPLAY", ":999")
+        .env("CLIPASTE_BACKEND", "wayland")
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    assert!(stdout(&out).contains("Watch mode requires data-control"));
+    assert!(!home.0.join("unsafe-paste-called").exists());
+}
+
+#[test]
+fn native_wayland_backend_accepts_data_control_and_empty_clipboard() {
+    if wsl_kernel() {
+        return;
+    }
+    let home = TestHome::new();
+    home.fake_curl();
+    home.script(
+        "wl-paste",
+        "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'wl-paste 2.2.1\\n'; exit 0; fi\n\
+         printf 'Nothing is copied\\n' >&2\nexit 1\n",
+    );
+    let out = home
+        .command()
+        .env("WAYLAND_DISPLAY", "wayland-test")
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+    assert!(stdout(&out).contains("Wayland data-control clipboard"));
+    assert!(!stdout(&out).contains("Using XWayland"));
+}
+
+#[test]
+fn wayland_requires_empty_selection_event_support() {
+    if wsl_kernel() {
+        return;
+    }
+    let home = TestHome::new();
+    home.fake_curl();
+    for (version, code) in [("2.1.0", 1), ("2.2.1", 0), ("2.3.0", 0)] {
+        home.script("wl-paste", &format!(
+            "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'wl-paste {version}\\n'; exit 0; fi\n\
+             printf called > \"$HOME/paste-called\"\nprintf 'Nothing is copied\\n' >&2\nexit 1\n"
+        ));
+        let out = home
+            .command()
+            .env("WAYLAND_DISPLAY", "wayland-test")
+            .args(["doctor", "--json"])
+            .output()
+            .unwrap();
+        assert_eq!(out.status.code(), Some(code), "{out:?}");
+        if code == 1 {
+            assert!(stdout(&out).contains("2.2 or later"));
+            assert!(!home.0.join("paste-called").exists());
+        } else {
+            assert!(home.0.join("paste-called").exists());
+        }
+    }
+}
+
+#[test]
+fn linux_ssh_setup_reports_linux_start_command_without_connecting() {
+    if wsl_kernel() {
+        return;
+    }
+    let home = TestHome::new();
+    home.fake_curl();
+    let out = home
+        .command()
+        .env("CLIPASTE_TEST_CURL_FAIL", "1")
+        .args(["ssh-setup", "user@example.invalid"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let error = String::from_utf8(out.stderr).unwrap();
+    assert!(error.contains("Linux graphical desktop session"));
+    assert!(!error.contains("brew"));
+    assert!(!home.0.join(".ssh").exists());
+}
+
+#[test]
+fn normal_stop_cleans_up_a_hung_clipboard_process_group() {
+    if wsl_kernel() {
+        return;
+    }
+    let home = TestHome::new();
+    home.script(
+        "xclip",
+        "#!/bin/sh\n/bin/sleep 30 &\nprintf '%s %s' \"$$\" \"$!\" > \"$HOME/children\"\nwait\n",
+    );
+    let mut daemon = home.command().env("DISPLAY", ":999").spawn().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let children = home.0.join("children");
+    while !children.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    if !children.exists() {
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+        panic!("clipboard command did not start");
+    }
+    // The readiness file is written by the hung command, not by a timed guess.
+    let pids = fs::read_to_string(children).unwrap();
+    unsafe { libc::kill(daemon.id() as i32, libc::SIGTERM) };
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while daemon.try_wait().unwrap().is_none() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    if daemon.try_wait().unwrap().is_none() {
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+        panic!("daemon did not stop");
+    }
+    for pid in pids.split_whitespace() {
+        let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap_or_default();
+        assert!(
+            status.is_empty()
+                || status
+                    .lines()
+                    .any(|line| line.starts_with("State:") && line.contains('Z')),
+            "clipboard subprocess {pid} still running: {status}"
+        );
+    }
 }

--- a/tests/linux_cli.rs
+++ b/tests/linux_cli.rs
@@ -367,12 +367,25 @@ fn normal_stop_cleans_up_a_hung_clipboard_process_group() {
     if wsl_kernel() {
         return;
     }
+    for args in [vec![], vec!["doctor", "--json"]] {
+        for signal in [libc::SIGINT, libc::SIGTERM] {
+            stop_hung_command(&args, signal);
+        }
+    }
+}
+
+fn stop_hung_command(args: &[&str], signal: libc::c_int) {
     let home = TestHome::new();
     home.script(
         "xclip",
         "#!/bin/sh\n/bin/sleep 30 &\nprintf '%s %s' \"$$\" \"$!\" > \"$HOME/children\"\nwait\n",
     );
-    let mut daemon = home.command().env("DISPLAY", ":999").spawn().unwrap();
+    let mut daemon = home
+        .command()
+        .args(args)
+        .env("DISPLAY", ":999")
+        .spawn()
+        .unwrap();
     let deadline = Instant::now() + Duration::from_secs(2);
     let children = home.0.join("children");
     while !children.exists() && Instant::now() < deadline {
@@ -385,7 +398,7 @@ fn normal_stop_cleans_up_a_hung_clipboard_process_group() {
     }
     // The readiness file is written by the hung command, not by a timed guess.
     let pids = fs::read_to_string(children).unwrap();
-    unsafe { libc::kill(daemon.id() as i32, libc::SIGTERM) };
+    unsafe { libc::kill(daemon.id() as i32, signal) };
     let deadline = Instant::now() + Duration::from_secs(2);
     while daemon.try_wait().unwrap().is_none() && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(5));


### PR DESCRIPTION
## Summary

Implements the Linux clipboard-host path discussed in #9, following the support
matrix and diagnostics work in #11. Thanks to @Palgogo for the detailed report
and for separating Linux clipboard hosts from remote consumers.

- Capture `image/png` on Linux desktops through real `wl-paste` or `xclip`,
  then serve the existing private PNG cache through the loopback HTTP bridge.
- Keep the Linux clipboard read-only. Do not inject text/file URLs or generate
  extra clipboard-history entries.
- Prefer native Wayland data-control. All Wayland reads use bounded, one-shot
  `--watch` callbacks, which refuse popup/focus-grabbing fallbacks. Require
  wl-clipboard 2.2+ for empty-selection events; ext-only compositors additionally
  need a build supporting ext-data-control.
- Explicitly warn when auto-selection falls back to XWayland through `DISPLAY`.
  Support `CLIPASTE_BACKEND=wayland|x11` overrides and actionable diagnostics.
- Bypass generated HTTP consumer shims, clear stale images on text/empty/private
  selections, reject bad PNGs without stopping the daemon, and recover deleted
  cache files. Bound command runtime/output and clean up child groups on stop.
- Preserve SSH/WSL consumer roles. Bind HTTP synchronously so an occupied port
  cannot leave a watcher running behind another daemon or tunnel.
- Add isolated Xvfb/Sway integration coverage and a Linux desktop CI job.

## Validation

- Linux: 56 unit tests and 13 CLI tests passed; strict Clippy passed.
- Real Xvfb and headless Sway with wl-clipboard 2.3.0 passed:
  startup capture, PNG HTTP bytes, doctor, port conflicts, replacement, text
  clearing, unchanged clipboard preservation, cache deduplication/permissions,
  recovery after cache deletion, malformed-image hold/recovery, and generated
  consumer helper downloads with host-side shim bypass.
- Wayland additionally passed private-image exclusion, sustained empty clipboard,
  empty-startup and recopy recovery.
- macOS: 67 unit tests passed; strict Clippy passed.
- Windows MSVC cross-target strict Clippy passed.
- Current head: `1f29ff17b3325aa5f8f6ce4e0a2b5569861cc156`.
  All four CI jobs passed: Linux, macOS, Windows, and real Linux desktop tests.
  CI: https://github.com/hqhq1025/clipaste/actions/runs/34580605368
- Independent re-review found no remaining substantiated P1/P2 issues after
  fixes. Stop tests cover daemon and doctor with both SIGINT and SIGTERM.
- Tests use isolated homes and virtual desktops, not the user's clipboard.
  The helper smoke test uses container loopback, not a claimed cross-host SSH test.

## Limits

Linux currently captures PNG clipboard data, not file-manager URI-only copies
or local terminal text-path injection. GNOME/Ubuntu native-app clipboard export
through XWayland has not been validated here; compositor/source-app combinations
need an end-to-end screenshot check. Wayland-only sessions without usable
data-control fail explicitly.

No release version, existing tag, installed service, or release asset is changed.
